### PR TITLE
 AP_Compass: correct edge case where checks pass when saved dev_id != detected dev_id

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -575,6 +575,17 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         return false;
     }
 
+    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_COMPASS)) {
+        // check compass offsets have been set.  AP_Arming only checks
+        // this if learning is off; Copter *always* checks.
+        if (!_compass.configured()) {
+            if (display_failure) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: Compass not calibrated");
+            }
+            return false;
+        }
+    }
+
     if (!copter.parachute.get_mttr_prearm_pass()) {
         if (display_failure) {
             gcs().send_text(MAV_SEVERITY_CRITICAL,"Arm: FTS state");

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -455,7 +455,7 @@ Compass::Compass(void) :
 
     // default device ids to zero.  init() method will overwrite with the actual device ids
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
-        _state[i].dev_id = 0;
+        _state[i].detected_dev_id = 0;
     }
 }
 
@@ -863,6 +863,7 @@ void
 Compass::save_offsets(uint8_t i)
 {
     _state[i].offset.save();  // save offsets
+    _state[i].dev_id.set_and_save(_state[i].detected_dev_id);
     _state[i].dev_id.save();  // save device id corresponding to these offsets
 }
 
@@ -983,16 +984,21 @@ bool Compass::configured(uint8_t i)
         return false;
     }
 
-    // backup detected dev_id
-    int32_t dev_id_orig = _state[i].dev_id;
+    // exit immediately if dev_id hasn't been detected
+    if (_state[i].detected_dev_id == 0) {
+        return false;
+    }
+
+    // back up cached value of dev_id
+    int32_t dev_id_cache_value = _state[i].dev_id;
 
     // load dev_id from eeprom
     _state[i].dev_id.load();
 
-    // if different then the device has not been configured
-    if (_state[i].dev_id != dev_id_orig) {
-        // restore device id
-        _state[i].dev_id = dev_id_orig;
+    // if dev_id loaded from eeprom is different from detected dev id or dev_id loaded from eeprom is different from cached dev_id, compass is unconfigured
+    if (_state[i].dev_id != _state[i].detected_dev_id || _state[i].dev_id != dev_id_cache_value) {
+        // restore cached value
+        _state[i].dev_id = dev_id_cache_value;
         // return failure
         return false;
     }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -456,6 +456,7 @@ Compass::Compass(void) :
     // default device ids to zero.  init() method will overwrite with the actual device ids
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
         _state[i].detected_dev_id = 0;
+        _state[i].dev_id = 0;
     }
 }
 

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -387,6 +387,7 @@ private:
         // saved to eeprom when offsets are saved allowing ram &
         // eeprom values to be compared as consistency check
         AP_Int32    dev_id;
+        uint32_t detected_dev_id;
 
         AP_Int8     use_for_yaw;
 

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -387,7 +387,7 @@ private:
         // saved to eeprom when offsets are saved allowing ram &
         // eeprom values to be compared as consistency check
         AP_Int32    dev_id;
-        uint32_t detected_dev_id;
+        int32_t detected_dev_id;
 
         AP_Int8     use_for_yaw;
 

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -107,6 +107,7 @@ uint8_t AP_Compass_Backend::register_compass(void) const
 void AP_Compass_Backend::set_dev_id(uint8_t instance, uint32_t dev_id)
 {
     _compass._state[instance].dev_id.set_and_notify(dev_id);
+    _compass._state[instance].detected_dev_id = dev_id;
 }
 
 /*


### PR DESCRIPTION
This allows a companion computer to set the COMPASS_DEV_ID parameter to enforce a specific hardware configuration.

upstream PR: https://github.com/ArduPilot/ardupilot/pull/7970