### PR TITLE
Copter: run compass_checks in arming checks

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -574,6 +574,10 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         }
         return false;
     }
+    
+    if (!compass_checks(display_failure)) {
+        return false;
+    }
 
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_COMPASS)) {
         // check compass offsets have been set.  AP_Arming only checks


### PR DESCRIPTION
This should run the field strength check continuously up until the vehicle arms.