### PR TITLE
Added pre-arm and pre-takeoff checks for GPS quality

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -428,7 +428,7 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
 
     float hacc, vacc;
     if (!copter.gps.horizontal_accuracy(hacc) ||
-        !copter.gps.horizontal_accuracy(vacc)) {
+        !copter.gps.vertical_accuracy(vacc)) {
         if (display_failure) {
             gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: No GPS accuracy");
         }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -426,6 +426,27 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
         return false;
     }
 
+    float hacc, vacc;
+    if (!copter.gps.horizontal_accuracy(hacc) ||
+        !copter.gps.horizontal_accuracy(vacc)) {
+        if (display_failure) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL,"PreArm: No GPS accuracy");
+        }
+        return false;
+    }
+    if (hacc > copter.matternet.arm_gps_hacc) {
+        if (display_failure) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS hacc %.2f", hacc);
+        }
+        return false;
+    }
+    if (vacc > copter.matternet.arm_gps_vacc) {
+        if (display_failure) {
+            gcs().send_text(MAV_SEVERITY_CRITICAL, "PreArm: GPS vacc %.2f", vacc);
+        }
+        return false;
+    }
+
     // if we got here all must be ok
     AP_Notify::flags.pre_arm_gps_check = true;
     return true;
@@ -795,4 +816,26 @@ void AP_Arming_Copter::set_pre_arm_check(bool b)
         copter.ap.pre_arm_check = b;
         AP_Notify::flags.pre_arm_check = b;
     }
+}
+
+/*
+  checks run before takeoff to check that GPS movement is within
+  acceptable range
+ */
+bool AP_Arming_Copter::pre_takeoff_checks(void)
+{
+    float pos_change, alt_change;
+    if (!copter.gps.get_pre_arm_pos_change(pos_change, alt_change)) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Takeoff: no GPS data");
+        return false;
+    }
+    if (pos_change > copter.matternet.tkoff_gps_pos_change) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Takeoff: pos change %.2f", pos_change);
+        return false;
+    }
+    if (pos_change > copter.matternet.tkoff_gps_alt_change) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Takeoff: alt change %.2f", alt_change);
+        return false;
+    }
+    return true;
 }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -590,12 +590,14 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         }
     }
 
+#if CONFIG_HAL_BOARD != HAL_BOARD_SITL
     if (!copter.parachute.get_mttr_prearm_pass()) {
         if (display_failure) {
             gcs().send_text(MAV_SEVERITY_CRITICAL,"Arm: FTS state");
         }
         return false;
     }
+#endif
 
     for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
         AP_RangeFinder_Backend *sensor = copter.rangefinder.get_backend(i);

--- a/ArduCopter/AP_Arming.h
+++ b/ArduCopter/AP_Arming.h
@@ -20,6 +20,9 @@ public:
 
     bool rc_calibration_checks(bool display_failure);
 
+    // checks run before auto-takeoff on MISSION_START allowed
+    bool pre_takeoff_checks(void);
+
 protected:
 
     bool pre_arm_checks(bool display_failure) override;

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -305,7 +305,8 @@ private:
 
     // altitude below which we do no navigation in auto takeoff
     float auto_takeoff_no_nav_alt_cm;
-    
+    float auto_takeoff_max_nav_alt_cm;
+
     RCMapper rcmap;
 
     // board specific config

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -140,6 +140,7 @@ public:
     friend class AP_Rally_Copter;
     friend class Parameters;
     friend class ParametersG2;
+    friend class ParametersMTTR;
     friend class AP_Avoidance_Copter;
 #if ADVANCED_FAILSAFE == ENABLED
     friend class AP_AdvancedFailsafe_Copter;
@@ -170,6 +171,7 @@ private:
     // Global parameters are all contained within the 'g' class.
     Parameters g;
     ParametersG2 g2;
+    ParametersMTTR matternet;
 
     // main loop scheduler
     AP_Scheduler scheduler;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -987,7 +987,9 @@ void GCS_MAVLINK_Copter::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_MISSION_START:
-            if (copter.motors->armed() && copter.set_mode(AUTO, MODE_REASON_GCS_COMMAND)) {
+            if (!copter.arming.pre_takeoff_checks()) {
+                result = MAV_RESULT_FAILED;
+            } else if (copter.motors->armed() && copter.set_mode(AUTO, MODE_REASON_GCS_COMMAND)) {
                 copter.set_auto_armed(true);
                 if (copter.mission.state() != AP_Mission::MISSION_RUNNING) {
                     copter.mission.start_or_resume();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -885,7 +885,11 @@ const AP_Param::Info Copter::var_info[] = {
     // @Group:
     // @Path: Parameters.cpp
     GOBJECT(g2, "",  ParametersG2),
-    
+
+    // @Group:
+    // @Path: Parameters.cpp
+    GOBJECT(matternet, "",  ParametersMTTR),
+
     AP_VAREND
 };
 
@@ -1031,6 +1035,56 @@ ParametersG2::ParametersG2(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
+
+
+/*
+  Matternet specific parameters
+ */
+const AP_Param::GroupInfo ParametersMTTR::var_info[] = {
+
+    // @Param: TOFF_POS_CHANGE
+    // @DisplayName: Maximum GPS pos change
+    // @Description: This is the maximum allowed position change since arming for automatic takeoff
+    // @Range: 0 5
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("TOFF_POS_CHANGE", 1, ParametersMTTR, tkoff_gps_pos_change, 1.0),
+
+    // @Param: TOFF_ALT_CHANGE
+    // @DisplayName: Maximum GPS alt change
+    // @Description: This is the maximum allowed altitude change since arming for automatic takeoff
+    // @Range: 0 5
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("TOFF_ALT_CHANGE", 2, ParametersMTTR, tkoff_gps_alt_change, 1.0),
+
+    // @Param: ARM_GPS_HACC
+    // @DisplayName: Maximum GPS HAcc on arming
+    // @Description: This is the maximum allowed GPS horizontal accuracy for arming
+    // @Range: 0 5
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("ARM_GPS_HACC", 3, ParametersMTTR, arm_gps_hacc, 1.0),
+
+    // @Param: ARM_GPS_VACC
+    // @DisplayName: Maximum GPS VAcc on arming
+    // @Description: This is the maximum allowed GPS vertical accuracy for arming
+    // @Range: 0 5
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("ARM_GPS_VACC", 4, ParametersMTTR, arm_gps_vacc, 1.0),
+    
+    AP_GROUPEND
+};
+
+/*
+  constructor for matternet object
+ */
+ParametersMTTR::ParametersMTTR(void)
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
 
 /*
   This is a conversion table from old parameter values to new

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1005,6 +1005,13 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 
     // ID 19 reserved for TCAL (PR pending)
     // ID 20 reserved for TX_TYPE (PR pending)
+
+    // @Param: WP_NAVALT_MAX
+    // @DisplayName: Maximum navigation altitude
+    // @Description: This is the altitude in meters above which full navigation attitude can begin. This applies in auto takeoff
+    // @Range: 0 5
+    // @User: Standard
+    AP_GROUPINFO("WP_NAVALT_MAX", 28, ParametersG2, wp_navalt_max, 0),
     
     AP_GROUPEND
 };

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -51,7 +51,7 @@ public:
         k_param_software_type,
         k_param_ins_old,                        // *** Deprecated, remove with next eeprom number change
         k_param_ins,                            // libraries/AP_InertialSensor variables
-        k_param_NavEKF2_old, // deprecated - remove
+        k_param_matternet,
         k_param_NavEKF2,
         k_param_g2, // 2nd block of parameters
         k_param_NavEKF3,
@@ -570,6 +570,23 @@ public:
     
     // control over servo output ranges
     SRV_Channels servo_channels;
+};
+
+/*
+  Matternet specific parameters. This is done as a separate block to
+  reduce the change of conflict on rebase
+ */
+class ParametersMTTR {
+public:
+    ParametersMTTR(void);
+
+    // var_info for holding Parameter information
+    static const struct AP_Param::GroupInfo var_info[];
+    
+    AP_Float tkoff_gps_pos_change;
+    AP_Float tkoff_gps_alt_change;
+    AP_Float arm_gps_hacc;
+    AP_Float arm_gps_vacc;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -514,6 +514,9 @@ public:
     // altitude at which nav control can start in takeoff
     AP_Float wp_navalt_min;
 
+    // altitude at which nav control reaches full range in takeoff
+    AP_Float wp_navalt_max;
+
     // button checking
     AP_Button button;
 

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -146,10 +146,13 @@ void Copter::auto_takeoff_set_start_alt(void)
 {
     // start with our current altitude
     auto_takeoff_no_nav_alt_cm = inertial_nav.get_altitude();
-    
+    auto_takeoff_max_nav_alt_cm = inertial_nav.get_altitude();
+
     if (!motors->armed() || !ap.auto_armed || !motors->get_interlock() || ap.land_complete) {
         // we are not flying, add the wp_navalt_min
         auto_takeoff_no_nav_alt_cm += g2.wp_navalt_min * 100;
+        auto_takeoff_max_nav_alt_cm += g2.wp_navalt_max * 100;
+        auto_takeoff_max_nav_alt_cm = MAX(auto_takeoff_max_nav_alt_cm,auto_takeoff_no_nav_alt_cm);
     }
 }
 
@@ -161,23 +164,38 @@ void Copter::auto_takeoff_set_start_alt(void)
 void Copter::auto_takeoff_attitude_run(float target_yaw_rate)
 {
     float nav_roll, nav_pitch;
-    
-    if (g2.wp_navalt_min > 0 && inertial_nav.get_altitude() < auto_takeoff_no_nav_alt_cm) {
-        // we haven't reached the takeoff navigation altitude yet
+
+    nav_roll = wp_nav->get_roll();
+    nav_pitch = wp_nav->get_pitch();
+
+    float alt_cm = inertial_nav.get_altitude();
+    if (g2.wp_navalt_min > 0 && alt_cm <= auto_takeoff_no_nav_alt_cm) {
+        // below no nav alt we zero roll and pitch demand
         nav_roll = 0;
         nav_pitch = 0;
+
 #if FRAME_CONFIG == HELI_FRAME
         // prevent hover roll starting till past specified altitude
         hover_roll_trim_scalar_slew = 0;        
 #endif
+
         // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
         pos_control->set_limit_accel_xy();
 
         wp_nav->shift_wp_origin_to_current_pos();
-        wp_nav->wp_and_spline_init();
-    } else {
-        nav_roll = wp_nav->get_roll();
-        nav_pitch = wp_nav->get_pitch();
+    } else if (g2.wp_navalt_min > 0 && alt_cm < auto_takeoff_max_nav_alt_cm) {
+        // between no nav alt and max nav alt we interpolate
+        // roll/pitch demand
+        float lean_limit = linear_interpolate(0, aparm.angle_max,
+                                              alt_cm,
+                                              auto_takeoff_no_nav_alt_cm, auto_takeoff_max_nav_alt_cm);
+        if (fabsf(nav_roll) > lean_limit ||
+            fabsf(nav_pitch) > lean_limit) {
+            nav_roll = constrain_float(nav_roll, -lean_limit, lean_limit);
+            nav_pitch = constrain_float(nav_pitch, -lean_limit, lean_limit);
+            // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
+            pos_control->set_limit_accel_xy();
+        }
     }
     
     // roll & pitch from waypoint controller, yaw rate from pilot

--- a/Tools/scripts/runcoptertest.py
+++ b/Tools/scripts/runcoptertest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import pexpect, time, sys
+from pymavlink import mavutil
+
+def wait_heartbeat(mav, timeout=10):
+    '''wait for a heartbeat'''
+    start_time = time.time()
+    while time.time() < start_time+timeout:
+        if mav.recv_match(type='HEARTBEAT', blocking=True, timeout=0.5) is not None:
+            return
+    failure("Failed to get heartbeat")    
+
+def wait_mode(mav, modes, timeout=10):
+    '''wait for one of a set of flight modes'''
+    start_time = time.time()
+    last_mode = None
+    while time.time() < start_time+timeout:
+        wait_heartbeat(mav, timeout=10)
+        if mav.flightmode != last_mode:
+            print("Flightmode %s" % mav.flightmode)
+            last_mode = mav.flightmode
+        if mav.flightmode in modes:
+            return
+    print("Failed to get mode from %s" % modes)
+    sys.exit(1)
+
+def wait_time(mav, simtime):
+    '''wait for simulation time to pass'''
+    imu = mav.recv_match(type='RAW_IMU', blocking=True)
+    t1 = imu.time_usec*1.0e-6
+    while True:
+        imu = mav.recv_match(type='RAW_IMU', blocking=True)
+        t2 = imu.time_usec*1.0e-6
+        if t2 - t1 > simtime:
+            break
+
+cmd = '../Tools/autotest/sim_vehicle.py -j4 -D'
+mavproxy = pexpect.spawn(cmd, logfile=sys.stdout, timeout=30)
+mavproxy.expect("Ready to FLY")
+
+mav = mavutil.mavlink_connection('127.0.0.1:14550')
+
+wait_time(mav, 2)
+mavproxy.send('mode GUIDED\n')
+wait_mode(mav, ['GUIDED'])
+mavproxy.expect('is using GPS')
+mavproxy.expect('is using GPS')
+mavproxy.send('arm throttle\n')
+mavproxy.expect('ARMED')
+mavproxy.send('mode AUTO\n')
+wait_mode(mav, ['AUTO'])
+wait_time(mav, 30)
+mavproxy.send('long MISSION_START\n')
+mavproxy.send('module load console\n')
+#mavproxy.send('module load map\n')
+mavproxy.logfile = None
+mavproxy.interact()

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -169,7 +169,7 @@ void AP_AHRS_NavEKF::update_EKF2(void)
 
             // calculate corrected gyro estimate for get_gyro()
             _gyro_estimate.zero();
-            if (primary_imu == -1) {
+            if (primary_imu == -1 || !_ins.get_gyro_health(primary_imu)) {
                 // the primary IMU is undefined so use an uncorrected default value from the INS library
                 _gyro_estimate = _ins.get_gyro();
             } else {
@@ -239,7 +239,7 @@ void AP_AHRS_NavEKF::update_EKF3(void)
 
             // calculate corrected gyro estimate for get_gyro()
             _gyro_estimate.zero();
-            if (primary_imu == -1) {
+            if (primary_imu == -1 || !_ins.get_gyro_health(primary_imu)) {
                 // the primary IMU is undefined so use an uncorrected default value from the INS library
                 _gyro_estimate = _ins.get_gyro();
             } else {

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -1010,11 +1010,15 @@ bool Compass::configured(uint8_t i)
 
 bool Compass::configured(void)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    return true;
+#else
     bool all_configured = true;
     for(uint8_t i=0; i<get_count(); i++) {
         all_configured = all_configured && (!use_for_yaw(i) || configured(i));
     }
     return all_configured;
+#endif
 }
 
 // Update raw magnetometer values from HIL data

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -388,6 +388,12 @@ public:
     // indicate which bit in LOG_BITMASK indicates gps logging enabled
     void set_log_gps_bit(uint32_t bit) { _log_gps_bit = bit; }
 
+    // get change in position and altitude since arming
+    bool get_pre_arm_pos_change(uint8_t instance, float &pos_change, float &alt_change) const;
+    bool get_pre_arm_pos_change(float &pos_change, float &alt_change) const {
+        return get_pre_arm_pos_change(primary_instance, pos_change, alt_change);
+    }
+
 protected:
 
     // configuration parameters
@@ -468,6 +474,8 @@ private:
     void detect_instance(uint8_t instance);
     void update_instance(uint8_t instance);
 
+    void update_position_change(uint8_t instance);
+
     /*
       buffer for re-assembling RTCM data for GPS injection.
       The 8 bit flags field in GPS_RTCM_DATA is interpreted as:
@@ -507,6 +515,12 @@ private:
     float _omega_lpf; // cutoff frequency in rad/sec of LPF applied to position offsets
     bool _output_is_blended; // true when a blended GPS solution being output
     uint8_t _blend_health_counter;  // 0 = perfectly health, 100 = very unhealthy
+
+    /*
+      track change in position and height since arming. Used for
+      pre-takeoff check
+     */
+    Location _arm_loc[GPS_MAX_RECEIVERS];
 
     // calculate the blend weight.  Returns true if blend could be calculated, false if not
     bool calc_blend_weights(void);

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -1248,41 +1248,62 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
 }
 
 void SITL_State::_update_gps_instance(SITL::SITL::GPSType gps_type, const struct gps_data *data, uint8_t instance) {
+    struct gps_data d2 = *data;
+
+    static uint32_t start_ms;
+    uint32_t now = AP_HAL::millis();
+    if (hal.util->get_soft_armed()) {
+        if (start_ms == 0) {
+            start_ms = now;
+        }
+        float dt = (now - start_ms) * 0.001;
+        // drift to N
+        //d2.speedN += _sitl->gps_drift_spd;
+        Location loc;
+        loc.lat = d2.latitude*1.0e7;
+        loc.lng = d2.longitude*1.0e7;
+        location_offset(loc, dt * _sitl->gps_drift_spd, 0);
+        d2.latitude = loc.lat * 1.0e-7;
+        d2.longitude = loc.lng * 1.0e-7;
+    } else {
+        start_ms = 0;
+    }
+
     switch (gps_type) {
         case SITL::SITL::GPS_TYPE_NONE:
             // no GPS attached
             break;
 
         case SITL::SITL::GPS_TYPE_UBLOX:
-            _update_gps_ubx(data, instance);
+            _update_gps_ubx(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_MTK:
-            _update_gps_mtk(data, instance);
+            _update_gps_mtk(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_MTK16:
-            _update_gps_mtk16(data, instance);
+            _update_gps_mtk16(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_MTK19:
-            _update_gps_mtk19(data, instance);
+            _update_gps_mtk19(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_NMEA:
-            _update_gps_nmea(data, instance);
+            _update_gps_nmea(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_SBP:
-            _update_gps_sbp(data, instance);
+            _update_gps_sbp(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_SBP2:
-            _update_gps_sbp2(data, instance);
+            _update_gps_sbp2(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_NOVA:
-            _update_gps_nova(data, instance);
+            _update_gps_nova(&d2, instance);
             break;
 
         case SITL::SITL::GPS_TYPE_FILE:

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -106,6 +106,9 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("GPS_LOCKTIME", 5, SITL,  gps_lock_time, 0),
     AP_GROUPINFO("ARSPD_FAIL_P", 6, SITL,  arspd_fail_pressure, 0),
     AP_GROUPINFO("ARSPD_PITOT",  7, SITL,  arspd_fail_pitot_pressure, 0),
+
+
+    AP_GROUPINFO("GPS_DRIFT_S",  35, SITL,  gps_drift_spd, 0),
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -157,6 +157,7 @@ public:
     AP_Float temp_flight;
     AP_Float temp_tconst;
     AP_Float temp_baro_factor;
+    AP_Float gps_drift_spd;
     
     uint16_t irlock_port;
 


### PR DESCRIPTION
This adds new Matternet specific parameters for checking GPS quality at both arming and at takeoff. The new parameters are:
 TOFF_POS_CHANGE: allowable position change between arming and takeoff
 TOFF_ALT_CHANGE: allowable altitude change between arming and takeoff
 ARM_GPS_HACC: max GPS reported horizontal accuracy for arming
 ARM_GPS_VACC: max GPS reported vertical accuracy for arming
The TOFF_* parameters apply when a MISSION_START is issued for automatic takeoff. The ARM_GPS_* parameters are applied at arming time.
In addition this PR includes changes to allow for SITL testing of GPS drift pre-takeoff. Using the SIM_GPS_DRIFT_S parameter the drift speed in m/s can be set. 

These pre-arm and pre-takeoff checks by themselves are not enough for full protection in poor GPS environments. In addition we need to prevent sudden attitude changes after takeoff is initiated due to changes in reported GPS position. That is achieved with a new WP_NAVALT_MAX parameter. That works like this:

 - below WP_NAVALT_MIN the attitude of the vehicle is kept completely level.
 - between WP_NAVALT_MIN and WP_NAVALT_MAX the allowable attitude control is linearly increases up to ANGLE_MAX
 - above WP_NAVALT_MAX the full ANGLE_MAX is available

this change prevents a sudden change in allowable attitude for position control which greatly reduces the chance of attitude overshoot at low altitude. The selection of WP_NAVALT_MIN and WP_NAVALT_MAX is highly dependent on the maximum wind conditions that the vehicle will operate in, and the proximity to obstacles that provide either a physical risk or a risk of GPS interference

This PR also includes a change to fix handling of an IMU failure. This is a critical fix for any vehicle using a Hex Cube.