### PR TITLE
Clamp rate integrators below WP_NAVALT_MIN

### DIFF
--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -182,6 +182,11 @@ void Copter::auto_takeoff_attitude_run(float target_yaw_rate)
         // tell the position controller that we have limited roll/pitch demand to prevent integrator buildup
         pos_control->set_limit_accel_xy();
 
+        // clear rate integrators till we reach min navigation altitude
+        attitude_control->get_rate_roll_pid().set_integrator(0);
+        attitude_control->get_rate_pitch_pid().set_integrator(0);
+        attitude_control->get_rate_yaw_pid().set_integrator(0);
+
         wp_nav->shift_wp_origin_to_current_pos();
     } else if (g2.wp_navalt_min > 0 && alt_cm < auto_takeoff_max_nav_alt_cm) {
         // between no nav alt and max nav alt we interpolate

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -161,7 +161,7 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
         return false;
     }
 
-    for (int i = 0 ; i < expected_reply_len ; i++) {
+    for (unsigned i = 0 ; i < expected_reply_len ; i++) {
         if (rx_bytes[i] != expected_reply[i]) {
             return false;
         }
@@ -371,7 +371,7 @@ bool AP_RangeFinder_LightWareI2C::sf20_parse_stream(uint8_t *stream_buf,
                        const char *string_identifier,
                        uint16_t &val) {
     size_t string_identifier_len = strlen(string_identifier);
-    for (int i = 0 ; i < string_identifier_len ; i++) {
+    for (unsigned i = 0 ; i < string_identifier_len ; i++) {
         if (stream_buf[*p_num_processed_chars] != string_identifier[i]) {
             return false;
         }


### PR DESCRIPTION
This prevents a small AHRS_TRIM error causing rate integrator buildup during the first phase of takeoff where we don't have good attitude control.
In testing that integrator buildup can cause a 5 degree pitch overshoot when the landing gear does leave the ground
