### PR TITLE
Copter: Added auto takeoff liftoff detector

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -309,6 +309,11 @@ private:
     float auto_takeoff_no_nav_alt_cm;
     float auto_takeoff_max_nav_alt_cm;
 
+    // minimum recorded barometric alt during takeoff. Used to detect
+    // the "dip" in barometric alt that happens on takeoff
+    float takeoff_baro_min_alt_m;
+    bool takeoff_liftoff_complete;
+
     RCMapper rcmap;
 
     // board specific config

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1081,6 +1081,24 @@ const AP_Param::GroupInfo ParametersMTTR::var_info[] = {
     // @Increment: 0.01
     // @User: Advanced
     AP_GROUPINFO("ARM_GPS_VACC", 4, ParametersMTTR, arm_gps_vacc, 1.0),
+
+    // @Param: TOFF_BARO_DIP
+    // @DisplayName: Barometric rise for liftoff completion
+    // @Description: This is amount of rise in barometer above min reading in takeoff before we consider that liftoff has completed
+    // @Units: m
+    // @Range: 0 5
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("TOFF_BARO_DIP", 5, ParametersMTTR, tkoff_baro_dip, 2.0),
+
+    // @Param: TOFF_HOV_PCT
+    // @DisplayName: Percent of hover throttle for liftoff
+    // @Description: This is percentage of hover throttle before we consider that liftoff is complete
+    // @Units: %
+    // @Range: 0 127
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("TOFF_HOV_PCT", 6, ParametersMTTR, tkoff_hover_pct, 80),
     
     AP_GROUPEND
 };

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -587,6 +587,8 @@ public:
     AP_Float tkoff_gps_alt_change;
     AP_Float arm_gps_hacc;
     AP_Float arm_gps_vacc;
+    AP_Float tkoff_baro_dip;
+    AP_Int8 tkoff_hover_pct;
 };
 
 extern const AP_Param::Info        var_info[];

--- a/ArduCopter/takeoff.cpp
+++ b/ArduCopter/takeoff.cpp
@@ -154,6 +154,10 @@ void Copter::auto_takeoff_set_start_alt(void)
         auto_takeoff_max_nav_alt_cm += g2.wp_navalt_max * 100;
         auto_takeoff_max_nav_alt_cm = MAX(auto_takeoff_max_nav_alt_cm,auto_takeoff_no_nav_alt_cm);
     }
+
+    // reset the min baro alt seen in takeoff
+    takeoff_baro_min_alt_m = barometer.get_altitude();
+    takeoff_liftoff_complete = false;
 }
 
 
@@ -168,8 +172,44 @@ void Copter::auto_takeoff_attitude_run(float target_yaw_rate)
     nav_roll = wp_nav->get_roll();
     nav_pitch = wp_nav->get_pitch();
 
+    /*
+      record the minimum barometer altitude we see in the
+      takeoff. This is used to detect the "dip" that happens on the
+      baro when the motors start applying thrust.
+     */
+    float barometer_alt = barometer.get_altitude();
+    if (barometer_alt < takeoff_baro_min_alt_m) {
+        takeoff_baro_min_alt_m = barometer_alt;
+    }
+
+    /*
+      check conditions for liftoff completion
+      We consider liftoff to be completed under one of 3 conditions:
+        1) the TOFF_BARO_DIP and TOFF_HOV_PCT are both zero
+        2) the barometric height has risen from the minimum by at least TOFF_BARO_DIP
+        2) the throttle has reached TOFF_HOV_PCT of the hover throttle
+     */
+    if (!takeoff_liftoff_complete) {
+        if (copter.matternet.tkoff_baro_dip > 0 &&
+            barometer_alt - takeoff_baro_min_alt_m >= copter.matternet.tkoff_baro_dip) {
+            takeoff_liftoff_complete = true;
+            gcs().send_text(MAV_SEVERITY_INFO, "LIFTOFF: baro %.1f thr=%.2f\n", barometer_alt - takeoff_baro_min_alt_m, motors->get_throttle());
+        }
+        if (copter.matternet.tkoff_hover_pct > 0 &&
+            motors->get_throttle() >= copter.matternet.tkoff_hover_pct * 0.01 * motors->get_throttle_hover()) {
+            takeoff_liftoff_complete = true;
+            gcs().send_text(MAV_SEVERITY_INFO, "LIFTOFF: throttle %.2f baro=%.1f\n", motors->get_throttle(), barometer_alt - takeoff_baro_min_alt_m);
+        }
+        if (copter.matternet.tkoff_baro_dip <= 0 &&
+            copter.matternet.tkoff_hover_pct <= 0) {
+            // both are disabled, do direct takeoff
+            takeoff_liftoff_complete = true;
+        }
+    }
+
+
     float alt_cm = inertial_nav.get_altitude();
-    if (g2.wp_navalt_min > 0 && alt_cm <= auto_takeoff_no_nav_alt_cm) {
+    if (!takeoff_liftoff_complete) {
         // below no nav alt we zero roll and pitch demand
         nav_roll = 0;
         nav_pitch = 0;
@@ -188,7 +228,9 @@ void Copter::auto_takeoff_attitude_run(float target_yaw_rate)
         attitude_control->get_rate_yaw_pid().set_integrator(0);
 
         wp_nav->shift_wp_origin_to_current_pos();
-    } else if (g2.wp_navalt_min > 0 && alt_cm < auto_takeoff_max_nav_alt_cm) {
+
+        auto_takeoff_max_nav_alt_cm = alt_cm + g2.wp_navalt_max * 100;
+    } else if (g2.wp_navalt_max > 0 && alt_cm < auto_takeoff_max_nav_alt_cm) {
         // between no nav alt and max nav alt we interpolate
         // roll/pitch demand
         float lean_limit = linear_interpolate(0, aparm.angle_max,


### PR DESCRIPTION
This changes the takeoff code to replace WP_NAVALT_MIN with a "liftoff detector". This removes the dependence on GPS altitude for detecting when it is safe to start maneuvering, which should prevent trying to maneuver while we do not yet have enough thrust or while we are still in contact with the ground.

We detect liftoff using a combination of the baro "dip" caused by downthrust of the motors and the throttle level relative to hover throttle. We introduce two new parameters:

  TOFF_BARO_DIP - the amount of rise in meters from minimum of barometer in takeoff
  TOFF_HOV_PCT - the percentage of hover throttle needed for liftoff

The liftoff is considered complete under any of these 3 conditions:
 1) both TOFF_BARO_DIP and TOFF_HOV_PCT are zero
 2) the barometer altitude has risen above the minimum baro alt since takeoff start by at least TOFF_BARO_DIP
 3) the motor throttle has reached at least TOFF_HOV_PCT percent of the hover throttle

While liftoff has not completed we do the following:
 - zero both navigation and rate integrators
 - set target XY coordinates for takeoff to current XY coordinates
 - force roll and pitch targets to zero

After liftoff is complete we start the ramp of the maximum roll/pitch until WP_NAVALT_MAX above the point that liftoff completed.