### PR TITLE
Copter: disable RC arming check in GUIDED mode

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -308,6 +308,9 @@ bool AP_Arming_Copter::motor_checks(bool display_failure)
 
 bool AP_Arming_Copter::pilot_throttle_checks(bool display_failure)
 {
+    if (rc_check_disabled) {
+        return true;
+    }
     // check throttle is above failsafe throttle
     // this is near the bottom to allow other failures to be displayed before checking pilot throttle
     if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
@@ -641,7 +644,7 @@ bool AP_Arming_Copter::arm_checks(bool display_failure, bool arming_from_gcs)
 #endif
 
     // check throttle
-    if ((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) {
+    if (((checks_to_perform == ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_RC)) && !rc_check_disabled) {
          #if FRAME_CONFIG == HELI_FRAME
         const char *rc_item = "Collective";
         #else

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -268,7 +268,7 @@ void Copter::set_mode_SmartRTL_or_RTL(mode_reason_t reason)
 }
 
 bool Copter::should_disarm_on_failsafe() {
-    if (ap.in_arming_delay) {
+    if (ap.in_arming_delay && control_mode != GUIDED) {
         return true;
     }
 
@@ -280,6 +280,14 @@ bool Copter::should_disarm_on_failsafe() {
         case AUTO:
             // if mission has not started AND vehicle is landed, disarm motors
             return !ap.auto_armed && ap.land_complete;
+        case GUIDED:
+            if (g.failsafe_throttle == FS_THR_ENABLED_CONTINUE_MISSION ||
+                g.failsafe_throttle == FS_THR_ENABLED_CONTINUE_MISSION_ALWAYS_LAND) {
+                // prevent needing to arm twice in GUIDED
+                return false;
+            }
+            return ap.land_complete;
+
         default:
             // used for AltHold, Guided, Loiter, RTL, Circle, Drift, Sport, Flip, Autotune, PosHold
             // if landed disarm

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -242,6 +242,9 @@ bool Copter::set_mode(control_mode_t mode, mode_reason_t reason)
     // update notify object
     notify_flight_mode();
 
+    // we want to allow arming with no RC in GUIDED mode
+    arming.disable_RC_check(mode == GUIDED);
+
     // return success
     return true;
 }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -507,7 +507,7 @@ bool AP_Arming::manual_transmitter_checks(bool report)
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_RC)) {
 
-        if (AP_Notify::flags.failsafe_radio) {
+        if (AP_Notify::flags.failsafe_radio && !rc_check_disabled) {
             check_failed(ARMING_CHECK_RC, report, "Radio failsafe on");
             return false;
         }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -59,6 +59,11 @@ public:
     // get expected magnetic field strength
     uint16_t compass_magfield_expected() const;
 
+    // allow RC check to be disabled for some modes
+    void disable_RC_check(bool disable) {
+        rc_check_disabled = disable;
+    }
+
     // rudder arming support
     enum ArmingRudder {
         ARMING_RUDDER_DISABLED  = 0,
@@ -91,6 +96,7 @@ protected:
     uint8_t                 arming_method;          // how the vehicle was armed
     uint32_t                last_accel_pass_ms[INS_MAX_INSTANCES];
     uint32_t                last_gyro_pass_ms[INS_MAX_INSTANCES];
+    bool                    rc_check_disabled;
 
     virtual bool barometer_checks(bool report);
 


### PR DESCRIPTION
This allows for auto missions with RC off, while enabling RC arming checks in manual modes
The vehicle should be setup with:
 ARMING_CHECK=1
 FS_THR_ENABLE=6
the FS_THR_ENABLE=6 is to give the behaviour that RC fail while in AUTO is ignored, but in manual modes it does LAND
This PR also fixes the issue with needing to arm twice in GUIDED mode if RC is off
