### PR TITLE
Force first EKF lane and report worst variance over MAVLink

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1252,11 +1252,70 @@ void  NavEKF2::getFilterGpsStatus(int8_t instance, nav_gps_status &status)
 }
 
 // send an EKF_STATUS_REPORT message to GCS
+// for each variance we send the maximum of all lanes
 void NavEKF2::send_status_report(mavlink_channel_t chan)
 {
-    if (core) {
-        core[primary].send_status_report(chan);
+    nav_filter_status filterStatus = core[primary].filterStatus;
+
+    // prepare flags
+    uint16_t flags = 0;
+    if (filterStatus.flags.attitude) {
+        flags |= EKF_ATTITUDE;
     }
+    if (filterStatus.flags.horiz_vel) {
+        flags |= EKF_VELOCITY_HORIZ;
+    }
+    if (filterStatus.flags.vert_vel) {
+        flags |= EKF_VELOCITY_VERT;
+    }
+    if (filterStatus.flags.horiz_pos_rel) {
+        flags |= EKF_POS_HORIZ_REL;
+    }
+    if (filterStatus.flags.horiz_pos_abs) {
+        flags |= EKF_POS_HORIZ_ABS;
+    }
+    if (filterStatus.flags.vert_pos) {
+        flags |= EKF_POS_VERT_ABS;
+    }
+    if (filterStatus.flags.terrain_alt) {
+        flags |= EKF_POS_VERT_AGL;
+    }
+    if (filterStatus.flags.const_pos_mode) {
+        flags |= EKF_CONST_POS_MODE;
+    }
+    if (filterStatus.flags.pred_horiz_pos_rel) {
+        flags |= EKF_PRED_POS_HORIZ_REL;
+    }
+    if (filterStatus.flags.pred_horiz_pos_abs) {
+        flags |= EKF_PRED_POS_HORIZ_ABS;
+    }
+
+    // get variances
+    float velVar=0, posVar=0, hgtVar=0, tasVar=0, magVarLen=0;
+    Vector2f offset;
+
+    for (uint8_t i=0; i<num_cores; i++) {
+        float c_velVar, c_posVar, c_hgtVar, c_tasVar;
+        Vector3f c_magVar;
+        core[i].getVariances(c_velVar, c_posVar, c_hgtVar, c_magVar, c_tasVar, offset);
+        velVar = MAX(velVar, c_velVar);
+        hgtVar = MAX(hgtVar, c_hgtVar);
+        tasVar = MAX(tasVar, c_tasVar);
+        magVarLen = MAX(magVarLen, c_magVar.length());
+    }
+
+    // Only report range finder normalised innovation levels if the EKF needs the data for primary
+    // height estimation or optical flow operation. This prevents false alarms at the GCS if a
+    // range finder is fitted for other applications
+    float temp;
+    if ((_useRngSwHgt > 0) || core[primary].PV_AidingMode == NavEKF2_core::AID_RELATIVE || core[primary].flowDataValid) {
+        temp = sqrtf(core[primary].auxRngTestRatio);
+    } else {
+        temp = 0.0f;
+    }
+
+    // send message
+    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, magVarLen, temp);
 }
 
 // provides the height limit to be observed by the control loops

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -767,7 +767,7 @@ void NavEKF2::UpdateFilter(void)
 
     // when disarmed force lane1 if it is healthy. This is a temporary
     // workaround for poor performance of the 2nd IMU
-    if (!hal.util->get_soft_armed() && primary != 0 && core[0].healthy()) {
+    if (!hal.util->get_soft_armed() && primary != 0) {
         primary = 0;
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -765,6 +765,12 @@ void NavEKF2::UpdateFilter(void)
         }
     }
 
+    // when disarmed force lane1 if it is healthy. This is a temporary
+    // workaround for poor performance of the 2nd IMU
+    if (!hal.util->get_soft_armed() && primary != 0 && core[0].healthy()) {
+        primary = 0;
+    }
+
     check_log_write();
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -58,6 +58,8 @@ class AP_AHRS;
 class NavEKF2_core
 {
 public:
+    friend class NavEKF2;
+
     // Constructor
     NavEKF2_core(void);
 


### PR DESCRIPTION
This forces the first EKF lane while disarmed, preventing a condition where a lane switch can happen while waiting for good GPS lock.
It also changes the MAVLink EKF_STATUS_REPORT message to show the maximum of all scaled innovations across all lanes, so that an existing MAVLink GCS can know if one of the lanes is unhealthy
