### PR TITLE
Added BATTERY_RESET mavlink command

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -491,10 +491,26 @@ bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance)
 bool AP_BattMonitor::reset_remaining(uint16_t battery_mask, float percentage)
 {
     bool ret = true;
+    BatteryFailsafe highest_failsafe = BatteryFailsafe_None;
     for (uint8_t i = 0; i < _num_instances; i++) {
         if ((1U<<i) & battery_mask) {
-            ret &= drivers[i]->reset_remaining(percentage);
+            bool ok = drivers[i]->reset_remaining(percentage);
+            if (ok) {
+                state[i].failsafe = check_failsafe(i);
+            }
+            ret &= ok;
         }
+        if (state[i].failsafe > highest_failsafe) {
+            highest_failsafe = state[i].failsafe;
+        }
+    }
+
+    // If all backends are not in failsafe then set overall failsafe state
+    if (highest_failsafe == BatteryFailsafe_None) {
+        _highest_failsafe_priority = INT8_MAX;
+        _has_triggered_failsafe = false;
+        // and reset notify flag
+        AP_Notify::flags.failsafe_battery = false;
     }
     return ret;
 }

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -484,6 +484,21 @@ bool AP_BattMonitor::get_temperature(float &temperature, const uint8_t instance)
 }
 
 
+/*
+  reset battery remaining percentage for batteries that integrate to
+  calculate percentage remaining
+*/
+bool AP_BattMonitor::reset_remaining(uint16_t battery_mask, float percentage)
+{
+    bool ret = true;
+    for (uint8_t i = 0; i < _num_instances; i++) {
+        if ((1U<<i) & battery_mask) {
+            ret &= drivers[i]->reset_remaining(percentage);
+        }
+    }
+    return ret;
+}
+
 namespace AP {
 
 AP_BattMonitor &battery()

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -164,6 +164,9 @@ public:
     float get_resistance() const { return get_resistance(AP_BATT_PRIMARY_INSTANCE); }
     float get_resistance(uint8_t instance) const { return state[instance].resistance; }
 
+    // reset battery remaining percentage
+    bool reset_remaining(uint16_t battery_mask, float percentage);
+
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -91,3 +91,23 @@ void AP_BattMonitor_Backend::update_resistance_estimate()
     // update estimated voltage without sag
     _state.voltage_resting_estimate = _state.voltage + _state.current_amps * _state.resistance;
 }
+
+/*
+  default implementation for reset_remaining(). This sets consumed_wh
+  and consumed_mah based on the given percentage. Use percentage=100
+  for a full battery
+*/
+bool AP_BattMonitor_Backend::reset_remaining(float percentage)
+{
+    percentage = constrain_float(percentage, 0, 100);
+    const float used_proportion = (100 - percentage) * 0.01;
+    _state.consumed_mah = used_proportion * _params._pack_capacity;
+    // without knowing the history we can't do consumed_wh
+    // accurately. Best estimate is based on current voltage. This
+    // will be good when resetting the battery to a value close to
+    // full charge
+    _state.consumed_wh = _state.consumed_mah * 1000 * _state.voltage;
+
+    return true;
+}
+

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.h
@@ -53,6 +53,9 @@ public:
     virtual void handle_bi_msg(float voltage, float current,
             float temperature) {}
 
+    // reset remaining percentage to given value
+    virtual bool reset_remaining(float percentage);
+
 protected:
     AP_BattMonitor                      &_mon;      // reference to front-end
     AP_BattMonitor::BattMonitor_State   &_state;    // reference to this instances state (held in the front-end)

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.h
@@ -40,6 +40,9 @@ public:
     // bebop provides current info
     bool has_current() const override { return true; };
 
+    // don't allow reset of remaining capacity for bebop battery
+    bool reset_remaining(float percentage) override { return false; }
+
 private:
     float _prev_vbat_raw;
     float _prev_vbat;

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus.h
@@ -42,6 +42,9 @@ public:
     // all smart batteries are expected to provide current
     bool has_current() const override { return true; }
 
+    // don't allow reset of remaining capacity for SMBus
+    bool reset_remaining(float percentage) override { return false; }
+    
     void init(void) override;
 
 protected:

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -352,6 +352,7 @@ protected:
     virtual MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_long_t &packet);
     virtual MAV_RESULT _handle_command_preflight_calibration_baro();
 
+    MAV_RESULT handle_command_battery_reset(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_mag_cal(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_long_message(mavlink_command_long_t &packet);
     MAV_RESULT handle_command_camera(const mavlink_command_long_t &packet);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2596,6 +2596,16 @@ MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_comma
     return _handle_command_preflight_calibration(packet);
 }
 
+MAV_RESULT GCS_MAVLINK::handle_command_battery_reset(const mavlink_command_long_t &packet)
+{
+    const uint16_t battery_mask = packet.param1;
+    const float percentage = packet.param2;
+    if (AP::battery().reset_remaining(battery_mask, percentage)) {
+        return MAV_RESULT_ACCEPTED;
+    }
+    return MAV_RESULT_FAILED;
+}
+
 MAV_RESULT GCS_MAVLINK::handle_command_mag_cal(const mavlink_command_long_t &packet)
 {
     Compass *compass = get_compass();
@@ -2718,6 +2728,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_message(mavlink_command_long_t &pack
         result = handle_command_preflight_calibration(packet);
         break;
 
+    case MAV_CMD_BATTERY_RESET:
+        result = handle_command_battery_reset(packet);
+        break;
+        
     case MAV_CMD_FLASH_BOOTLOADER:
         result = handle_command_flash_bootloader(packet);
         break;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -245,7 +245,8 @@ void GCS_MAVLINK::send_distance_sensor(const AP_RangeFinder_Backend *sensor, con
         sensor->get_mav_distance_sensor_type(),  // type from MAV_DISTANCE_SENSOR enum
         instance,                                // onboard ID of the sensor == instance
         sensor->orientation(),                   // direction the sensor faces from MAV_SENSOR_ORIENTATION enum
-        0);                                      // Measurement covariance in centimeters, 0 for unknown / invalid readings
+        0,                                      // Measurement covariance in centimeters, 0 for unknown / invalid readings
+        0, 0, nullptr);
 }
 
 bool GCS_MAVLINK::send_distance_sensor() const
@@ -321,7 +322,8 @@ bool GCS_MAVLINK::send_proximity() const
                     MAV_DISTANCE_SENSOR_LASER,                      // type from MAV_DISTANCE_SENSOR enum
                     PROXIMITY_SENSOR_ID_START + i,                  // onboard ID of the sensor
                     dist_array.orientation[i],                      // direction the sensor faces from MAV_SENSOR_ORIENTATION enum
-                    0);                                             // Measurement covariance in centimeters, 0 for unknown / invalid readings
+                    0,                                             // Measurement covariance in centimeters, 0 for unknown / invalid readings
+                    0, 0, nullptr);
         }
     }
 
@@ -338,7 +340,8 @@ bool GCS_MAVLINK::send_proximity() const
                 MAV_DISTANCE_SENSOR_LASER,                                // type from MAV_DISTANCE_SENSOR enum
                 PROXIMITY_SENSOR_ID_START + PROXIMITY_MAX_DIRECTION + 1,  // onboard ID of the sensor
                 MAV_SENSOR_ROTATION_PITCH_90,                             // direction upwards
-                0);                                                       // Measurement covariance in centimeters, 0 for unknown / invalid readings
+                0,                                                       // Measurement covariance in centimeters, 0 for unknown / invalid readings
+                0, 0, nullptr);
     }
     return true;
 }


### PR DESCRIPTION
This allows for pre-flight battery swap by sending a MAV_CMD_BATTERY_RESET command. The command takes two parameters:
 1) a mask of what batteries to reset (use -1 for all batteries)
 2) a battery percentage to set the battery to (use 100 for a full battery)

Note: this does not clear a battery failsafe if one has been triggered
