### PR TITLE
AP_GPS_UBLOX: add support for TIMEGPS message. used to get gps week

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -73,7 +73,15 @@ AP_GPS_UBLOX::_request_next_config(void)
         return;
     }
 
-   Debug("Unconfigured messages: %d Current message: %d\n", _unconfigured_messages, _next_message);
+    if (_unconfigured_messages == CONFIG_RATE_SOL && havePvtMsg && haveTimeGPSMsg) {
+        /*
+          we don't need SOL if we have PVT and TIMEGPS. This is needed
+          as F9P doesn't support the SOL message
+         */
+        _unconfigured_messages &= ~CONFIG_RATE_SOL;
+    }
+
+    Debug("Unconfigured messages: 0x%x Current message: %u\n", (unsigned)_unconfigured_messages, (unsigned)_next_message);
 
    // check AP_GPS_UBLOX.h for the enum that controls the order.
    // This switch statement isn't maintained against the enum in order to reduce code churn
@@ -819,6 +827,11 @@ AP_GPS_UBLOX::_parse_gps(void)
                                              state.instance + 1,
                                              _version.hwVersion,
                                              _version.swVersion);
+            // check for F9. The F9 does not respond to SVINFO, so we need to use MON_VER
+            // for hardware generation
+            if (strncmp(_version.hwVersion, "00190000", 8) == 0) {
+                _hardware_generation = UBLOX_F9;
+            }
             break;
         default:
             unexpected_message();
@@ -1034,8 +1047,10 @@ AP_GPS_UBLOX::_parse_gps(void)
         break;
     case MSG_TIMEGPS:
         Debug("MSG_TIMEGPS");
-        if (_buffer.timegps.valid & UBX_TIMEGPS_VALID_WEEK_MASK)
+        if (_buffer.timegps.valid & UBX_TIMEGPS_VALID_WEEK_MASK) {
             state.time_week = _buffer.timegps.week;
+        }
+        haveTimeGPSMsg = true;
         break;
     case MSG_VELNED:
         Debug("MSG_VELNED");
@@ -1332,6 +1347,11 @@ bool AP_GPS_UBLOX::get_lag(float &lag_sec) const
     case UBLOX_7:
     case UBLOX_M8:
         // based on flight logs the 7 and 8 series seem to produce about 120ms lag
+        lag_sec = 0.12f;
+        break;
+    case UBLOX_F9:
+        // F9 lag not verified yet from flight log, but likely to be at least
+        // as good as M8
         lag_sec = 0.12f;
         break;
     };

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -47,11 +47,14 @@
 #define UBLOX_MAX_GNSS_CONFIG_BLOCKS 7
 #define UBX_MSG_TYPES 2
 
+#define UBX_TIMEGPS_VALID_WEEK_MASK 0x2
+
 #define UBLOX_MAX_PORTS 6
 
 #define RATE_POSLLH 1
 #define RATE_STATUS 1
 #define RATE_SOL 1
+#define RATE_TIMEGPS 5
 #define RATE_PVT 1
 #define RATE_VELNED 1
 #define RATE_DOP 1
@@ -72,6 +75,8 @@
 #define CONFIG_GNSS          (1<<11)
 #define CONFIG_SBAS          (1<<12)
 #define CONFIG_RATE_PVT      (1<<13)
+#define CONFIG_RATE_TIMEGPS  (1<<14)
+#define CONFIG_LAST          (1<<15) // this must always be the last bit
 
 #define CONFIG_REQUIRED_INITIAL (CONFIG_RATE_NAV | CONFIG_RATE_POSLLH | CONFIG_RATE_STATUS | CONFIG_RATE_VELNED)
 
@@ -274,6 +279,15 @@ private:
         uint32_t heading_accuracy;
     };
 
+    struct PACKED ubx_nav_timegps {
+        uint32_t itow;
+        int32_t ftow;
+        uint16_t week;
+        int8_t leapS;
+        uint8_t valid; //  leapsvalid | weekvalid | tow valid;
+        uint32_t tAcc;
+    };
+
     // Lea6 uses a 60 byte message
     struct PACKED ubx_mon_hw_60 {
         uint32_t pinSel;
@@ -399,6 +413,7 @@ private:
         ubx_nav_dop dop;
         ubx_nav_solution solution;
         ubx_nav_pvt pvt;
+        ubx_nav_timegps timegps;
         ubx_nav_velned velned;
         ubx_cfg_msg_rate msg_rate;
         ubx_cfg_msg_rate_6 msg_rate_6;
@@ -436,6 +451,7 @@ private:
         MSG_DOP = 0x4,
         MSG_SOL = 0x6,
         MSG_PVT = 0x7,
+        MSG_TIMEGPS = 0x20,
         MSG_VELNED = 0x12,
         MSG_CFG_CFG = 0x09,
         MSG_CFG_RATE = 0x08,
@@ -490,6 +506,7 @@ private:
         STEP_STATUS,
         STEP_POSLLH,
         STEP_VELNED,
+        STEP_TIMEGPS,
         STEP_POLL_SVINFO, // poll svinfo
         STEP_POLL_SBAS, // poll SBAS
         STEP_POLL_NAV, // poll NAV settings

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -494,6 +494,7 @@ private:
         UBLOX_6,
         UBLOX_7,
         UBLOX_M8,
+        UBLOX_F9 = 0x80, // comes from MON_VER hwVersion string
         UBLOX_UNKNOWN_HARDWARE_GENERATION = 0xff // not in the ublox spec used for
                                                  // flagging state in the driver
     };
@@ -565,6 +566,7 @@ private:
     bool noReceivedHdop;
     
     bool havePvtMsg;
+    bool haveTimeGPSMsg;
 
     bool        _configure_message_rate(uint8_t msg_class, uint8_t msg_id, uint8_t rate);
     void        _configure_rate(void);


### PR DESCRIPTION
This is needed for the uBlox F9P GPS
Not tested yet
