### PR TITLE
GCS_MAVLink: break out MTTR_FTS_VER string send

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -320,6 +320,8 @@ protected:
     void handle_send_autopilot_version(const mavlink_message_t *msg);
     MAV_RESULT handle_command_request_autopilot_capabilities(const mavlink_command_long_t &packet);
 
+    void send_matternet_FTS_version(void) const;
+
     virtual void send_banner();
 
     void handle_device_op_read(mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1547,6 +1547,8 @@ void GCS_MAVLINK::send_autopilot_version() const
         uid,
         uid2
     );
+
+    send_matternet_FTS_version();
 }
 
 
@@ -2293,9 +2295,6 @@ void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
 
     case MAVLINK_MSG_ID_AUTOPILOT_VERSION_REQUEST:
         handle_send_autopilot_version(msg);
-        char mttr_fts_text[50];
-        snprintf(mttr_fts_text, 50, "MTTR_FTS_VER: %s", AP_Parachute::mttr_get_fts_version());
-        send_text(MAV_SEVERITY_INFO, mttr_fts_text);
         break;
 
     case MAVLINK_MSG_ID_MISSION_WRITE_PARTIAL_LIST:
@@ -2443,9 +2442,6 @@ void GCS_MAVLINK::handle_common_mission_message(mavlink_message_t *msg)
 void GCS_MAVLINK::handle_send_autopilot_version(const mavlink_message_t *msg)
 {
     send_autopilot_version();
-    char mttr_fts_text[50];
-    snprintf(mttr_fts_text, 50, "MTTR_FTS_VER: %s", AP_Parachute::mttr_get_fts_version());
-    send_text(MAV_SEVERITY_INFO, mttr_fts_text);
 }
 
 void GCS_MAVLINK::send_banner()
@@ -2627,6 +2623,16 @@ MAV_RESULT GCS_MAVLINK::handle_command_request_autopilot_capabilities(const mavl
     send_autopilot_version();
 
     return MAV_RESULT_ACCEPTED;
+}
+
+/*
+  send Matternet FTS version string
+ */
+void GCS_MAVLINK::send_matternet_FTS_version(void) const
+{
+    char mttr_fts_text[50];
+    snprintf(mttr_fts_text, 50, "MTTR_FTS_VER: %s", AP_Parachute::mttr_get_fts_version());
+    gcs().send_text(MAV_SEVERITY_INFO, mttr_fts_text);
 }
 
 


### PR DESCRIPTION
and ensure it is sent on both capabilities and version request