### PR TITLE
Pr set f9p primary gps

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -126,6 +126,17 @@ public:
 
     const char *name() const override { return "u-blox"; }
 
+    enum ubx_hardware_version {
+        ANTARIS = 0,
+        UBLOX_5,
+        UBLOX_6,
+        UBLOX_7,
+        UBLOX_M8,
+        UBLOX_F9 = 0x80, // comes from MON_VER hwVersion string
+        UBLOX_UNKNOWN_HARDWARE_GENERATION = 0xff // not in the ublox spec used for
+                                                 // flagging state in the driver
+    };
+
 private:
     // u-blox UBX protocol essentials
     struct PACKED ubx_header {
@@ -488,16 +499,6 @@ private:
         NAV_STATUS_FIX_VALID = 1,
         NAV_STATUS_DGPS_USED = 2
     };
-    enum ubx_hardware_version {
-        ANTARIS = 0,
-        UBLOX_5,
-        UBLOX_6,
-        UBLOX_7,
-        UBLOX_M8,
-        UBLOX_F9 = 0x80, // comes from MON_VER hwVersion string
-        UBLOX_UNKNOWN_HARDWARE_GENERATION = 0xff // not in the ublox spec used for
-                                                 // flagging state in the driver
-    };
 
     enum config_step {
         STEP_PVT = 0,
@@ -593,7 +594,7 @@ private:
     }
 
     // returns hardware generation of the GPS
-    uint32_t hardware_generation() { 
+    uint32_t hardware_generation() const override { 
         return _hardware_generation;
     }
 };

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -591,4 +591,9 @@ private:
     uint8_t _ubx_msg_log_index(uint8_t ubx_msg) {
         return (uint8_t)(ubx_msg + (state.instance * UBX_MSG_TYPES));
     }
+
+    // returns hardware generation of the GPS
+    uint32_t hardware_generation() { 
+        return _hardware_generation;
+    }
 };

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -66,7 +66,7 @@ public:
     virtual bool prepare_for_arming(void) { return true; }
 
     // returns hardware generation variable
-    virtual uint32_t hardware_generation() { return 0; }
+    virtual uint32_t hardware_generation() const { return 0; }
 
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -65,6 +65,9 @@ public:
 
     virtual bool prepare_for_arming(void) { return true; }
 
+    // returns hardware generation variable
+    virtual uint32_t hardware_generation() { return 0; }
+
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)


### PR DESCRIPTION
Added logic for choosing F9P over other GPS as a primary GPS.