### PR TITLE
Pr set f9p primary gps

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -743,13 +743,13 @@ void AP_GPS::update(void)
                     GPS_Status status_i = state[i].status;
                     GPS_Status status_primary = state[primary_instance].status;
 
-                    // Treat U-blox F9 as SBAS as it is dual band GPS and is more accurate than M8 with SBAS                    
-                    if (status_i == GPS_OK_FIX_3D && strcmp(drivers[i]->name(), "u-blox") == 0 && drivers[i]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
+                    // Treat U-blox F9 as SBAS if it has more than or equal to 16 satellites, as it is dual band GPS and is more accurate than M8 with SBAS                    
+                    if (status_i == GPS_OK_FIX_3D && state[i].num_sats >= 16 && strcmp(drivers[i]->name(), "u-blox") == 0 && drivers[i]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
                         status_i = GPS_OK_FIX_3D_DGPS;
                     }
 
-                    // Treat U-blox F9 as SBAS as it is dual band GPS and is more accurate than M8 with SBAS                    
-                    if (status_primary == GPS_OK_FIX_3D && strcmp(drivers[primary_instance]->name(), "u-blox") == 0 && drivers[primary_instance]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
+                    // Treat U-blox F9 as SBAS if it has more than or equal to 16 satellites, as it is dual band GPS and is more accurate than M8 with SBAS
+                    if (status_primary == GPS_OK_FIX_3D && state[primary_instance].num_sats >= 16 && strcmp(drivers[primary_instance]->name(), "u-blox") == 0 && drivers[primary_instance]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
                         status_primary = GPS_OK_FIX_3D_DGPS;
                     }
 
@@ -759,7 +759,7 @@ void AP_GPS::update(void)
                         should_switch = true;
                     }
                     
-                    if (status_i == status_primary && !hal.util->get_soft_armed() && state[i].num_sats >= state[primary_instance].num_sats+3) {
+                    else if (status_i == status_primary && !hal.util->get_soft_armed() && state[i].num_sats >= state[primary_instance].num_sats+3) {
                         should_switch = true;                        
                     }
 

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -742,14 +742,15 @@ void AP_GPS::update(void)
                     
                     GPS_Status status_i = state[i].status;
                     GPS_Status status_primary = state[primary_instance].status;
+                      
 
-                    // Treat U-blox F9 as SBAS as it is dual band GPS and is more accurate than M8 with SBAS                    
-                    if (status_i == GPS_OK_FIX_3D && strcmp(drivers[i]->name(), "u-blox") == 0 && drivers[i]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
+                    // Treat U-blox F9 as SBAS if it has more than or equal to 16 satellites, as it is dual band GPS and is more accurate than M8 with SBAS                    
+                    if (status_i == GPS_OK_FIX_3D && state[i].num_sats >= 16 && strcmp(drivers[i]->name(), "u-blox") == 0 && drivers[i]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
                         status_i = GPS_OK_FIX_3D_DGPS;
                     }
 
-                    // Treat U-blox F9 as SBAS as it is dual band GPS and is more accurate than M8 with SBAS                    
-                    if (status_primary == GPS_OK_FIX_3D && strcmp(drivers[primary_instance]->name(), "u-blox") == 0 && drivers[primary_instance]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
+                    // Treat U-blox F9 as SBAS if it has more than or equal to 16 satellites, as it is dual band GPS and is more accurate than M8 with SBAS
+                    if (status_primary == GPS_OK_FIX_3D && state[primary_instance].num_sats >= 16 && strcmp(drivers[primary_instance]->name(), "u-blox") == 0 && drivers[primary_instance]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {
                         status_primary = GPS_OK_FIX_3D_DGPS;
                     }
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -126,6 +126,17 @@ public:
 
     const char *name() const override { return "u-blox"; }
 
+    enum ubx_hardware_version {
+        ANTARIS = 0,
+        UBLOX_5,
+        UBLOX_6,
+        UBLOX_7,
+        UBLOX_M8,
+        UBLOX_F9 = 0x80, // comes from MON_VER hwVersion string
+        UBLOX_UNKNOWN_HARDWARE_GENERATION = 0xff // not in the ublox spec used for
+                                                 // flagging state in the driver
+    };
+
 private:
     // u-blox UBX protocol essentials
     struct PACKED ubx_header {
@@ -488,16 +499,6 @@ private:
         NAV_STATUS_FIX_VALID = 1,
         NAV_STATUS_DGPS_USED = 2
     };
-    enum ubx_hardware_version {
-        ANTARIS = 0,
-        UBLOX_5,
-        UBLOX_6,
-        UBLOX_7,
-        UBLOX_M8,
-        UBLOX_F9 = 0x80, // comes from MON_VER hwVersion string
-        UBLOX_UNKNOWN_HARDWARE_GENERATION = 0xff // not in the ublox spec used for
-                                                 // flagging state in the driver
-    };
 
     enum config_step {
         STEP_PVT = 0,
@@ -593,7 +594,7 @@ private:
     }
 
     // returns hardware generation of the GPS
-    uint32_t hardware_generation() { 
+    uint32_t hardware_generation() const override { 
         return _hardware_generation;
     }
 };

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -591,4 +591,9 @@ private:
     uint8_t _ubx_msg_log_index(uint8_t ubx_msg) {
         return (uint8_t)(ubx_msg + (state.instance * UBX_MSG_TYPES));
     }
+
+    // returns hardware generation of the GPS
+    uint32_t hardware_generation() { 
+        return _hardware_generation;
+    }
 };

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -66,7 +66,7 @@ public:
     virtual bool prepare_for_arming(void) { return true; }
 
     // returns hardware generation variable
-    virtual uint32_t hardware_generation() { return 0; }
+    virtual uint32_t hardware_generation() const { return 0; }
 
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -65,6 +65,9 @@ public:
 
     virtual bool prepare_for_arming(void) { return true; }
 
+    // returns hardware generation variable
+    virtual uint32_t hardware_generation() { return 0; }
+
 protected:
     AP_HAL::UARTDriver *port;           ///< UART we are attached to
     AP_GPS &gps;                        ///< access to frontend (for parameters)


### PR DESCRIPTION
Prefers F9P over M8 during disarm, in case F9P has 16 or more satellites.
In flight switched GPS only if the fix type of currently used GPS is less than the other available GPS.