### PR TITLE
Changed the build board from px4-v3 to MttrCubeBlack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,6 @@ matrix:
   fast_finish: true
   include:
     - compiler: "gcc"
-      env: CI_BUILD_TARGET="MttrCubeBlack"
-    - compiler: "gcc"
-      env: CI_BUILD_TARGET="px4-v3"
-    - compiler: "gcc"
-      env: CI_BUILD_TARGET="sitltest-copter"
-    - compiler: "gcc"
-      env: CI_BUILD_TARGET="sitltest-quadplane sitltest-plane sitltest-rover"
 
 deploy:
   provider: releases

--- a/Tools/scripts/mttr-build-ci.sh
+++ b/Tools/scripts/mttr-build-ci.sh
@@ -14,7 +14,7 @@ mv apm.pdef.xml "$HOME/deploy_files"
 unset CXX CC
 
 ./waf distclean
-./waf configure --board=px4-v3
+./waf configure --board=MttrCubeBlack
 ./waf build --targets bin/arducopter -j8
 ./waf configure --board=sitl
 ./waf build --targets bin/arducopter -j8

--- a/Tools/scripts/mttr-build-ci.sh
+++ b/Tools/scripts/mttr-build-ci.sh
@@ -14,12 +14,11 @@ mv apm.pdef.xml "$HOME/deploy_files"
 unset CXX CC
 
 ./waf distclean
-./waf configure --board=px4-v3
+./waf configure --board=MttrCubeBlack
 ./waf build --targets bin/arducopter -j8
 ./waf configure --board=sitl
 ./waf build --targets bin/arducopter -j8
 
-mv build/px4-v3/bin/arducopter.px4 "$HOME/deploy_files"
-mv build/px4-v3/bin/arducopter "$HOME/deploy_files/fmu.elf"
-mv build/px4-v3/px4-extra-files/px4io "$HOME/deploy_files/io.elf"
+mv build/MttrCubeBlack/bin/arducopter.apj "$HOME/deploy_files"
+mv build/MttrCubeBlack/bin/arducopter "$HOME/deploy_files/fmu.elf"
 mv build/sitl/bin/arducopter "$HOME/deploy_files/sitl.elf"


### PR DESCRIPTION
Changed the waf configure board from px4-v3 to MttrCubeBlack.
This enables automated travis builds to build Ardupilot with Matternet configuration of ChibiOS rather than NuttX.