### PR TITLE
AP_NavEKF2: added EK2_MAG_LRN_LIM

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -560,6 +560,14 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Units: mGauss
     AP_GROUPINFO("MAG_EF_LIM", 52, NavEKF2, _mag_ef_limit, 50),
 
+    // @Param: MAG_LRN_LIM
+    // @DisplayName: Magnetometer offset learning limit
+    // @Description: This limits the size of the learned magnetometer offsets. A value of zero means no limit. Limiting the learned offsets can be helpful when the compass calibration is known to be good and the vehicle is operating in an environment that can lead to significant incorrect learned offsets due to temporary local fields
+    // @User: Advanced
+    // @Range: 0 500
+    // @Units: mGauss
+    AP_GROUPINFO("MAG_LRN_LIM", 53, NavEKF2, _mag_learn_limit, 0),
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -405,6 +405,7 @@ private:
     AP_Int8 _magMask;               // Bitmask forcng specific EKF core instances to use simple heading magnetometer fusion.
     AP_Int8 _originHgtMode;         // Bitmask controlling post alignment correction and reporting of the EKF origin height.
     AP_Int16 _mag_ef_limit;         // limit on difference between WMM tables and learned earth field.
+    AP_Int16 _mag_learn_limit;      // limit on learned magnetometer offsets
 
     // Tuning parameters
     const float gpsNEVelVarAccScale = 0.05f;       // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1423,6 +1423,17 @@ void NavEKF2_core::MagTableConstrain(void)
                                                    table_earth_field_ga.z+limit_ga);
 }
 
+// constrain states using limit on mag offsets
+void NavEKF2_core::MagOffsetConstrain(void)
+{
+    if (frontend->_mag_learn_limit > 0) {
+        float limit_ga = frontend->_mag_learn_limit * 0.001f;
+        stateStruct.body_magfield.x = constrain_float(stateStruct.body_magfield.x, -limit_ga, limit_ga);
+        stateStruct.body_magfield.y = constrain_float(stateStruct.body_magfield.y, -limit_ga, limit_ga);
+        stateStruct.body_magfield.z = constrain_float(stateStruct.body_magfield.z, -limit_ga, limit_ga);
+    }
+}
+
 // constrain states to prevent ill-conditioning
 void NavEKF2_core::ConstrainStates()
 {
@@ -1449,6 +1460,8 @@ void NavEKF2_core::ConstrainStates()
         // use table constrain
         MagTableConstrain();
     }
+
+    MagOffsetConstrain();
 
     // body magnetic field limit
     for (uint8_t i=19; i<=21; i++) statesArray[i] = constrain_float(statesArray[i],-0.5f,0.5f);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -491,6 +491,9 @@ private:
     // constrain earth field using WMM tables
     void MagTableConstrain(void);
 
+    // constrain mag offsets
+    void MagOffsetConstrain(void);
+    
     // fuse selected position, velocity and height measurements
     void FuseVelPosNED();
 


### PR DESCRIPTION
This sets a limit on EKF2 magnetometer offset learning. This is an attempt to cope with sites where localized magnetic fields are causing significant innovations which trigger learned biases which take several minutes to recover. This PR is currently for testing purposes only, it is possible that limiting the offsets in this way will lead to the errors being pushed into other states of the EKF which could lead to instability. We are already constraining the earth field states against the WMM, so the error may be pushed into bias states for other sensors, or just produce an incorrect yaw estimate.
I suggest we start with EK2_MAG_LRN_LIM=50 and see if that produces a sufficient reduction in the incorrect mag bias learning. 
This change does rely on having well calibrated compasses. It will reduce our ability to cope with poor initial compass offsets
