### PR TITLE
Switched mavlink submodule source to matternet's mavlink fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = git://github.com/google/benchmark.git
 [submodule "modules/mavlink"]
 	path = modules/mavlink
-	url = git://github.com/ArduPilot/mavlink
+	url = git://github.com/matternet/mavlink
 [submodule "gtest"]
 	path = modules/gtest
 	url = git://github.com/ArduPilot/googletest


### PR DESCRIPTION
Switched Mavlink submodule source from Ardupilot master's fork of Mavlink repository to Matternet's fork of Mavlink repository.