### PR TITLE
Switched mavlink hash from Ardupilot mavlink to Matternet mavlink fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = git://github.com/google/benchmark.git
 [submodule "modules/mavlink"]
 	path = modules/mavlink
-	url = git://github.com/ArduPilot/mavlink
+	url = git://github.com/matternet/mavlink
 [submodule "gtest"]
 	path = modules/gtest
 	url = git://github.com/ArduPilot/googletest


### PR DESCRIPTION
Switched mavlink hash from Ardupilot masters branch, mavlink fork to Matternet's mavlink fork's master branch.
Updated to the latest available mavlink commit.