### PR TITLE
Fix GPS outage bug

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -448,6 +448,10 @@ AP_GPS_UBLOX::read(void)
 				goto reset;
             }
             _payload_counter = 0;                               // prepare to receive payload
+            if (_payload_length == 0) {
+                // bypass payload and go straight to checksum
+                _step++;
+            }
             break;
 
         // Receive message data

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -547,6 +547,9 @@ private:
     uint32_t        _unconfigured_messages;
     uint8_t         _hardware_generation;
 
+    // support saving GPST messages
+    void            log_write_stats();
+    uint32_t        _last_log_stats_ms;
 
     // do we have new position information?
     bool            _new_position:1;
@@ -567,6 +570,13 @@ private:
     
     bool havePvtMsg;
     bool haveTimeGPSMsg;
+
+    struct {
+        uint32_t total_bytes;
+        uint32_t crc_errors;
+        uint32_t reset_errors;
+        uint32_t zero_payload_errors;
+    } _stats;
 
     bool        _configure_message_rate(uint8_t msg_class, uint8_t msg_id, uint8_t rate);
     void        _configure_rate(void);

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -110,7 +110,8 @@ const struct UnitStructure log_Units[] = {
     { 'v', "V" },             // Volt
     { 'P', "Pa" },            // Pascal
     { 'w', "Ohm" },           // Ohm
-    { 'z', "Hz" }             // Hertz
+    { 'z', "Hz" },            // Hertz
+    { '#', "instance" }       // (e.g.)Sensor instance number
 };
 
 // this multiplier information applies to the raw value present in the


### PR DESCRIPTION
This fixes a bug in u-blox protocol parsing that could cause a single lost byte to lead to GPS disconnect and reset. The problem happens if the bytes after the lost bytes contain a pattern that is formed like a u-blox packet with zero payload size. In that case we would process several kByte of data before finally resetting the device 4 seconds later.
This also adds logging of the event in a new GPST message, along with logging of CRC errors, resets and total traffic on GPS UARTs
