### PR TITLE
Add support for RTCM injection to UAVCAN GPS modules

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -782,9 +782,13 @@ void AP_GPS::handle_gps_inject(const mavlink_message_t *msg)
 {
     mavlink_gps_inject_data_t packet;
     mavlink_msg_gps_inject_data_decode(msg, &packet);
-    //TODO: check target
 
-    inject_data(packet.data, packet.len);
+    if (packet.len > sizeof(packet.data)) {
+        // invalid packet
+        return;
+    }
+
+    handle_gps_rtcm_fragment(0, packet.data, packet.len);
 }
 
 /*
@@ -881,7 +885,7 @@ void AP_GPS::lock_port(uint8_t instance, bool lock)
 }
 
 // Inject a packet of raw binary to a GPS
-void AP_GPS::inject_data(uint8_t *data, uint16_t len)
+void AP_GPS::inject_data(const uint8_t *data, uint16_t len)
 {
     //Support broadcasting to all GPSes.
     if (_inject_to == GPS_RTK_INJECT_TO_ALL) {
@@ -893,7 +897,7 @@ void AP_GPS::inject_data(uint8_t *data, uint16_t len)
     }
 }
 
-void AP_GPS::inject_data(uint8_t instance, uint8_t *data, uint16_t len)
+void AP_GPS::inject_data(uint8_t instance, const uint8_t *data, uint16_t len)
 {
     if (instance < GPS_MAX_RECEIVERS && drivers[instance] != nullptr) {
         drivers[instance]->inject_data(data, len);
@@ -1030,21 +1034,20 @@ bool AP_GPS::blend_health_check() const
 }
 
 /*
-   re-assemble GPS_RTCM_DATA message
+   re-assemble fragmented RTCM data
  */
-void AP_GPS::handle_gps_rtcm_data(const mavlink_message_t *msg)
+void AP_GPS::handle_gps_rtcm_fragment(uint8_t flags, const uint8_t *data, uint8_t len)
 {
-    mavlink_gps_rtcm_data_t packet;
-    mavlink_msg_gps_rtcm_data_decode(msg, &packet);
-
-    if (packet.len > MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN) {
-        // invalid packet
-        return;
+    // allow backends access to the unfragmented data (for UAVCAN)
+    for (uint8_t instance=0; instance<num_instances; instance++) {
+        if (drivers[instance]) {
+            drivers[instance]->handle_rtcm_data(flags, data, len);
+        }
     }
 
-    if ((packet.flags & 1) == 0) {
+    if ((flags & 1) == 0) {
         // it is not fragmented, pass direct
-        inject_data(packet.data, packet.len);
+        inject_data(data, len);
         return;
     }
 
@@ -1057,8 +1060,8 @@ void AP_GPS::handle_gps_rtcm_data(const mavlink_message_t *msg)
         }
     }
 
-    uint8_t fragment = (packet.flags >> 1U) & 0x03;
-    uint8_t sequence = (packet.flags >> 3U) & 0x1F;
+    uint8_t fragment = (flags >> 1U) & 0x03;
+    uint8_t sequence = (flags >> 3U) & 0x1F;
 
     // see if this fragment is consistent with existing fragments
     if (rtcm_buffer->fragments_received &&
@@ -1074,15 +1077,15 @@ void AP_GPS::handle_gps_rtcm_data(const mavlink_message_t *msg)
     rtcm_buffer->fragments_received |= (1U << fragment);
 
     // copy the data
-    memcpy(&rtcm_buffer->buffer[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*(uint16_t)fragment], packet.data, packet.len);
+    memcpy(&rtcm_buffer->buffer[MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*(uint16_t)fragment], data, len);
 
     // when we get a fragment of less than max size then we know the
     // number of fragments. Note that this means if you want to send a
     // block of RTCM data of an exact multiple of the buffer size you
     // need to send a final packet of zero length
-    if (packet.len < MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN) {
+    if (len < MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN) {
         rtcm_buffer->fragment_count = fragment+1;
-        rtcm_buffer->total_length = (MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*fragment) + packet.len;
+        rtcm_buffer->total_length = (MAVLINK_MSG_GPS_RTCM_DATA_FIELD_DATA_LEN*fragment) + len;
     } else if (rtcm_buffer->fragments_received == 0x0F) {
         // special case of 4 full fragments
         rtcm_buffer->fragment_count = 4;
@@ -1097,6 +1100,22 @@ void AP_GPS::handle_gps_rtcm_data(const mavlink_message_t *msg)
         inject_data(rtcm_buffer->buffer, rtcm_buffer->total_length);
         memset(rtcm_buffer, 0, sizeof(*rtcm_buffer));
     }
+}
+
+/*
+   re-assemble GPS_RTCM_DATA message
+ */
+void AP_GPS::handle_gps_rtcm_data(const mavlink_message_t *msg)
+{
+    mavlink_gps_rtcm_data_t packet;
+    mavlink_msg_gps_rtcm_data_decode(msg, &packet);
+
+    if (packet.len > sizeof(packet.data)) {
+        // invalid packet
+        return;
+    }
+
+    handle_gps_rtcm_fragment(packet.flags, packet.data, packet.len);
 }
 
 void AP_GPS::Write_DataFlash_Log_Startup_messages()

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -423,6 +423,9 @@ public:
         return get_pre_arm_pos_change(primary_instance, pos_change, alt_change);
     }
 
+    // handle possibly fragmented RTCM injection data
+    void handle_gps_rtcm_fragment(uint8_t flags, const uint8_t *data, uint8_t len);
+
 protected:
 
     // configuration parameters
@@ -535,9 +538,8 @@ private:
     void handle_gps_inject(const mavlink_message_t *msg);
 
     //Inject a packet of raw binary to a GPS
-    void inject_data(uint8_t *data, uint16_t len);
-    void inject_data(uint8_t instance, uint8_t *data, uint16_t len);
-
+    void inject_data(const uint8_t *data, uint16_t len);
+    void inject_data(uint8_t instance, const uint8_t *data, uint16_t len);
 
     // GPS blending and switching
     Vector2f _NE_pos_offset_m[GPS_MAX_RECEIVERS]; // Filtered North,East position offset from GPS instance to blended solution in _output_state.location (m)

--- a/libraries/AP_GPS/AP_GPS_UAVCAN.h
+++ b/libraries/AP_GPS/AP_GPS_UAVCAN.h
@@ -37,10 +37,15 @@ public:
 
     const char *name() const override { return "UAVCAN"; }
 
+    // handling of fragmented RTCM data
+    void handle_rtcm_data(uint8_t flags, const uint8_t *data, uint16_t len) override;
+
 private:
     bool _new_data;
     uint8_t _manager;
 
     AP_GPS::GPS_State _interm_state;
     AP_HAL::Semaphore *_sem_gnss;
+    static uint8_t instance_count;
+    uint8_t instance;
 };

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -43,6 +43,10 @@ public:
 
     virtual void inject_data(const uint8_t *data, uint16_t len);
 
+    // allow handling of fragmented RTCM data by backends. Used to
+    // forward GPS_RTCM_DATA from MAVLink over UAVCAN
+    virtual void handle_rtcm_data(uint8_t flags, const uint8_t *data, uint16_t len) {}
+
     //MAVLink methods
     virtual bool supports_mavlink_gps_rtk_message() { return false; }
     virtual void send_mavlink_gps_rtk(mavlink_channel_t chan);

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -155,6 +155,9 @@ public:
     void SRV_send_servos();
     void SRV_send_esc();
 
+    // send GNSS Inject packets. Same conventions as MAVLink GPS_RTCM_DATA
+    void send_GNSS_Inject(uint8_t flags, const uint8_t *data, uint8_t len);
+
     template <typename DataType_>
     class RegistryBinder {
     protected:

--- a/libraries/AP_UAVCAN/dsdl/ardupilot/equipment/gnss/20002.Inject.uavcan
+++ b/libraries/AP_UAVCAN/dsdl/ardupilot/equipment/gnss/20002.Inject.uavcan
@@ -1,0 +1,8 @@
+#
+# GNSS Inject, used by autopilots to forward GPS_RTCM_DATA or GPS_INJECT mavlink msgs
+# to GNSS nodes. Normally sent as broadcast
+
+# flags follows the same conventions as MAVLink GPS_RTCM_DATA
+uint8 flags
+
+uint8[<=180] data


### PR DESCRIPTION
This allows for NTRIP RTCM data to be used with UAVCAN GPS modules
