### PR TITLE
AP_GPS: fixed GPS to UART mapping

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -275,14 +275,34 @@ AP_GPS::AP_GPS()
     _singleton = this;
 }
 
+// return true if a specific type of GPS uses a UART
+bool AP_GPS::needs_uart(GPS_Type type) const
+{
+    switch (type) {
+    case GPS_TYPE_NONE:
+    case GPS_TYPE_HIL:
+    case GPS_TYPE_UAVCAN:
+    case GPS_TYPE_MAV:
+        return false;
+    default:
+        break;
+    }
+    return true;
+}
+
 /// Startup initialisation.
 void AP_GPS::init(const AP_SerialManager& serial_manager)
 {
     primary_instance = 0;
 
     // search for serial ports with gps protocol
-    _port[0] = serial_manager.find_serial(AP_SerialManager::SerialProtocol_GPS, 0);
-    _port[1] = serial_manager.find_serial(AP_SerialManager::SerialProtocol_GPS, 1);
+    uint8_t uart_idx = 0;
+    for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
+        if (needs_uart((GPS_Type)_type[i].get())) {
+            _port[i] = serial_manager.find_serial(AP_SerialManager::SerialProtocol_GPS, uart_idx);
+            uart_idx++;
+        }
+    }
     _last_instance_swap_ms = 0;
 
     // Initialise class variables used to do GPS blending

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -762,7 +762,16 @@ void AP_GPS::update(void)
                     
                     GPS_Status status_i = state[i].status;
                     GPS_Status status_primary = state[primary_instance].status;
-                      
+
+                    if (_type[i] == GPS_TYPE_UAVCAN && _type[1-i] != GPS_TYPE_UAVCAN && status_i == GPS_OK_FIX_3D) {
+                        // if this is a UAVCAN GPS and the other GPS
+                        // is not UAVCAN then we don't know what type
+                        // it is. It is likely F9, so make status=3 be
+                        // equal to status=4 for comparison purposes
+                        // so we choose it over a 2nd M8 with SBAS
+                        // lock
+                        status_i = GPS_OK_FIX_3D_DGPS;
+                    }
 
                     // Treat U-blox F9 as SBAS if it has more than or equal to 16 satellites, as it is dual band GPS and is more accurate than M8 with SBAS                    
                     if (status_i == GPS_OK_FIX_3D && state[i].num_sats >= 16 && strcmp(drivers[i]->name(), "u-blox") == 0 && drivers[i]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9) {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -566,6 +566,8 @@ private:
 
     bool should_df_log() const;
 
+    bool needs_uart(GPS_Type type) const;
+
     // Auto configure types
     enum GPS_AUTO_CONFIG {
         GPS_AUTO_CONFIG_DISABLE = 0,


### PR DESCRIPTION
this allows for first GPS as UAVCAN and 2nd as UART. That is not
possible currently unless you waste a uart