### PR TITLE
Added support for fixed yaw mag calibration

### DIFF
--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -45,6 +45,10 @@ extern AP_HAL::HAL& hal;
 #define HAL_COMPASS_AUTO_ROT_DEFAULT 2
 #endif
 
+#ifndef HAL_COMPASS_MAX_SENSORS
+#define HAL_COMPASS_MAX_SENSORS 3
+#endif
+
 const AP_Param::GroupInfo Compass::var_info[] = {
     // index 0 was used for the old orientation matrix
 

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -453,7 +453,32 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     // @Description: When enabled this will automatically check the orientation of compasses on successful completion of compass calibration. If set to 2 then external compasses will have their orientation automatically corrected.
     // @Values: 0:Disabled,1:CheckOnly,2:CheckAndFix
     AP_GROUPINFO("AUTO_ROT", 35, Compass, _rotate_auto, HAL_COMPASS_AUTO_ROT_DEFAULT),
-    
+
+    // @Param: SCALE
+    // @DisplayName: Compass1 scale factor
+    // @Description: Scaling factor for first compass to compensate for sensor scaling errors. If this is 0 then no scaling is done
+    // @User: Standard
+    // @Range: 0 1.3
+    AP_GROUPINFO("SCALE", 40, Compass, _state[0].scale_factor, 0),
+
+#if HAL_COMPASS_MAX_SENSORS > 1
+    // @Param: SCALE2
+    // @DisplayName: Compass2 scale factor
+    // @Description: Scaling factor for 2nd compass to compensate for sensor scaling errors. If this is 0 then no scaling is done
+    // @User: Standard
+    // @Range: 0 1.3
+    AP_GROUPINFO("SCALE2", 41, Compass, _state[1].scale_factor, 0),
+#endif
+
+#if HAL_COMPASS_MAX_SENSORS > 2
+    // @Param: SCALE3
+    // @DisplayName: Compass3 scale factor
+    // @Description: Scaling factor for 3rd compass to compensate for sensor scaling errors. If this is 0 then no scaling is done
+    // @User: Standard
+    // @Range: 0 1.3
+    AP_GROUPINFO("SCALE3", 42, Compass, _state[2].scale_factor, 0),
+#endif
+
     AP_GROUPEND
 };
 
@@ -1102,6 +1127,14 @@ Compass::set_and_save_offdiagonals(uint8_t i, const Vector3f &offdiagonals)
 }
 
 void
+Compass::set_and_save_scale_factor(uint8_t i, float scale_factor)
+{
+    if (i < COMPASS_MAX_INSTANCES) {
+        _state[i].scale_factor.set_and_save(scale_factor);
+    }
+}
+
+void
 Compass::save_offsets(uint8_t i)
 {
     _state[i].offset.save();  // save offsets
@@ -1385,6 +1418,19 @@ bool Compass::consistent() const
         if (xy_len_diff > AP_COMPASS_MAX_XY_LENGTH_DIFF) {
             return false;
         }
+    }
+    return true;
+}
+
+/*
+  return true if we have a valid scale factor
+ */
+bool Compass::have_scale_factor(uint8_t i) const
+{
+    if (i >= get_count() ||
+        _state[i].scale_factor < COMPASS_MIN_SCALE_FACTOR ||
+        _state[i].scale_factor > COMPASS_MAX_SCALE_FACTOR) {
+        return false;
     }
     return true;
 }

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -479,6 +479,13 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     AP_GROUPINFO("SCALE3", 42, Compass, _state[2].scale_factor, 0),
 #endif
 
+    // @Param: OPTIONS
+    // @DisplayName: Compass options
+    // @Description: This sets options to change the behaviour of the compass
+    // @Bitmask: 0:CalRequireGPS
+    // @User: Advanced
+    AP_GROUPINFO("OPTIONS", 43, Compass, _options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -478,6 +478,12 @@ private:
 
     AP_Int16 _offset_max;
 
+    // bitmask of options
+    enum class Option : uint16_t {
+        CAL_REQUIRE_GPS = (1U<<0),
+    };
+    AP_Int16 _options;
+
     CompassCalibrator _calibrator[COMPASS_MAX_INSTANCES];
 
     // per-motor compass compensation

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -330,6 +330,12 @@ public:
 
     uint8_t get_filter_range() const { return uint8_t(_filter_range.get()); }
 
+    /*
+      fast compass calibration given vehicle position and yaw
+     */
+    MAV_RESULT mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
+                                 float lat_deg, float lon_deg);
+
 private:
     static Compass *_singleton;
     /// Register a new compas driver, allocating an instance number
@@ -355,6 +361,12 @@ private:
     // see if we already have probed a i2c driver by bus number and address
     bool _have_i2c_driver(uint8_t bus_num, uint8_t address) const;
 
+    /*
+      get mag field with the effects of offsets, diagonals and
+      off-diagonals removed
+    */
+    bool get_uncorrected_field(uint8_t instance, Vector3f &field);
+    
     //keep track of which calibrators have been saved
     bool _cal_saved[COMPASS_MAX_INSTANCES];
     bool _cal_autosave;

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -104,6 +104,7 @@ public:
     void set_and_save_offsets(uint8_t i, const Vector3f &offsets);
     void set_and_save_diagonals(uint8_t i, const Vector3f &diagonals);
     void set_and_save_offdiagonals(uint8_t i, const Vector3f &diagonals);
+    void set_and_save_scale_factor(uint8_t i, float scale_factor);
 
     /// Saves the current offset x/y/z values for one or all compasses
     ///
@@ -121,6 +122,9 @@ public:
     /// Return the current field as a Vector3f in milligauss
     const Vector3f &get_field(uint8_t i) const { return _state[i].field; }
     const Vector3f &get_field(void) const { return get_field(get_primary()); }
+
+    /// Return true if we have set a scale factor for a compass
+    bool have_scale_factor(uint8_t i) const;
 
     // compass calibrator interface
     void compass_cal_update();
@@ -442,6 +446,7 @@ private:
         AP_Vector3f offset;
         AP_Vector3f diagonals;
         AP_Vector3f offdiagonals;
+        AP_Float    scale_factor;
 
         // device id detected at init.
         // saved to eeprom when offsets are saved allowing ram &

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -59,6 +59,12 @@ void AP_Compass_Backend::correct_field(Vector3f &mag, uint8_t i)
     // add in the basic offsets
     mag += offsets;
 
+    // add in scale factor, use a wide sanity check. The calibrator
+    // uses a narrower check.
+    if (_compass.have_scale_factor(i)) {
+        mag *= state.scale_factor;
+    }
+
     // apply eliptical correction
     Matrix3f mat(
         diagonals.x, offdiagonals.x, offdiagonals.y,

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -1,6 +1,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_AHRS/AP_AHRS.h>
+#include <AP_GPS/AP_GPS.h>
 
 #include "AP_Compass.h"
 
@@ -355,4 +357,118 @@ MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_long_t &packet)
     }
     
     return result;
+}
+
+/*
+  get mag field with the effects of offsets, diagonals and
+  off-diagonals removed
+ */
+bool Compass::get_uncorrected_field(uint8_t instance, Vector3f &field)
+{
+    // form eliptical correction matrix and invert it. This is
+    // needed to remove the effects of the eliptical correction
+    // when calculating new offsets
+    const Vector3f &diagonals = get_diagonals(instance);
+    const Vector3f &offdiagonals = get_offdiagonals(instance);
+    Matrix3f mat {
+        diagonals.x, offdiagonals.x, offdiagonals.y,
+        offdiagonals.x,    diagonals.y, offdiagonals.z,
+        offdiagonals.y, offdiagonals.z,    diagonals.z
+    };
+    if (!mat.invert()) {
+        return false;
+    }
+
+    // get corrected field
+    field = get_field(instance);
+
+    // remove impact of diagonals and off-diagonals
+    field = mat * field;
+
+    // remove impact of offsets
+    field -= get_offsets(instance);
+
+    return true;
+}
+
+/*
+  fast compass calibration given vehicle position and yaw. This
+  results in zero diagonal and off-diagonal elements, so is only
+  suitable for vehicles where the field is close to spherical. It is
+  useful for large vehicles where moving the vehicle to calibrate it
+  is difficult.
+
+  The offsets of the selected compasses are set to values to bring
+  them into consistency with the WMM tables at the given latitude and
+  longitude. If compass_mask is zero then all enabled compasses are
+  calibrated.
+
+  This assumes that the compass is correctly scaled in milliGauss
+*/
+MAV_RESULT Compass::mag_cal_fixed_yaw(float yaw_deg, uint8_t compass_mask,
+                                      float lat_deg, float lon_deg)
+{
+    if (is_zero(lat_deg) && is_zero(lon_deg)) {
+        Location loc;
+        // get AHRS position. If unavailable then try GPS location
+        if (!AP::ahrs().get_position(loc)) {
+            if (AP::gps().status() < AP_GPS::GPS_OK_FIX_3D) {
+                gcs().send_text(MAV_SEVERITY_ERROR, "Mag: no position available");
+                return MAV_RESULT_FAILED;
+            }
+            loc = AP::gps().location();
+        }
+        lat_deg = loc.lat * 1.0e-7;
+        lon_deg = loc.lng * 1.0e-7;
+    }
+
+    // get the magnetic field intensity and orientation
+    float intensity;
+    float declination;
+    float inclination;
+    if (!AP_Declination::get_mag_field_ef(lat_deg, lon_deg, intensity, declination, inclination)) {
+        gcs().send_text(MAV_SEVERITY_ERROR, "Mag: WMM table error");
+        return MAV_RESULT_FAILED;
+    }
+
+    // create a field vector and rotate to the required orientation
+    Vector3f field(1e3f * intensity, 0.0f, 0.0f);
+    Matrix3f R;
+    R.from_euler(0.0f, -ToRad(inclination), ToRad(declination));
+    field = R * field;
+
+    Matrix3f dcm;
+    dcm.from_euler(AP::ahrs().roll, AP::ahrs().pitch, radians(yaw_deg));
+
+    // Rotate into body frame using provided yaw
+    field = dcm.transposed() * field;
+
+    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+        if (compass_mask != 0 && ((1U<<i) & compass_mask) == 0) {
+            // skip this compass
+            continue;
+        }
+        if (!use_for_yaw(i)) {
+            continue;
+        }
+        if (!healthy(i)) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Mag[%u]: unhealthy\n", i);
+            return MAV_RESULT_FAILED;
+        }
+
+        Vector3f measurement;
+        if (!get_uncorrected_field(i, measurement)) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Mag[%u]: bad uncorrected field", i);
+            return MAV_RESULT_FAILED;
+        }
+
+        Vector3f offsets = field - measurement;
+        set_and_save_offsets(i, offsets);
+        Vector3f one{1,1,1};
+        set_and_save_diagonals(i, one);
+        Vector3f zero{0,0,0};
+        set_and_save_offdiagonals(i, zero);
+    }
+
+    return MAV_RESULT_ACCEPTED;
 }

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -1,5 +1,6 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Notify/AP_Notify.h>
+#include <AP_GPS/AP_GPS.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_GPS/AP_GPS.h>
@@ -50,6 +51,12 @@ bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
     }
     if (!use_for_yaw(i)) {
         return false;
+    }
+    if (_options.get() & uint16_t(Option::CAL_REQUIRE_GPS)) {
+        if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
+            gcs().send_text(MAV_SEVERITY_ERROR, "Compass cal requires GPS lock");
+            return false;
+        }
     }
     if (!is_calibrating()) {
         AP_Notify::events.initiated_compass_cal = 1;

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -43,8 +43,7 @@ Compass::compass_cal_update()
     }
 }
 
-bool
-Compass::_start_calibration(uint8_t i, bool retry, float delay)
+bool Compass::_start_calibration(uint8_t i, bool retry, float delay)
 {
     if (!healthy(i)) {
         return false;
@@ -78,8 +77,7 @@ Compass::_start_calibration(uint8_t i, bool retry, float delay)
     return true;
 }
 
-bool
-Compass::_start_calibration_mask(uint8_t mask, bool retry, bool autosave, float delay, bool autoreboot)
+bool Compass::_start_calibration_mask(uint8_t mask, bool retry, bool autosave, float delay, bool autoreboot)
 {
     _cal_autosave = autosave;
     _compass_cal_autoreboot = autoreboot;
@@ -95,8 +93,7 @@ Compass::_start_calibration_mask(uint8_t mask, bool retry, bool autosave, float 
     return true;
 }
 
-void
-Compass::start_calibration_all(bool retry, bool autosave, float delay, bool autoreboot)
+void Compass::start_calibration_all(bool retry, bool autosave, float delay, bool autoreboot)
 {
     _cal_autosave = autosave;
     _compass_cal_autoreboot = autoreboot;
@@ -108,8 +105,7 @@ Compass::start_calibration_all(bool retry, bool autosave, float delay, bool auto
     }
 }
 
-void
-Compass::_cancel_calibration(uint8_t i)
+void Compass::_cancel_calibration(uint8_t i)
 {
     AP_Notify::events.initiated_compass_cal = 0;
 
@@ -120,24 +116,21 @@ Compass::_cancel_calibration(uint8_t i)
     _calibrator[i].clear();
 }
 
-void
-Compass::_cancel_calibration_mask(uint8_t mask)
+void Compass::_cancel_calibration_mask(uint8_t mask)
 {
-    for(uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
-        if((1<<i) & mask) {
+    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+        if ((1<<i) & mask) {
             _cancel_calibration(i);
         }
     }
 }
 
-void
-Compass::cancel_calibration_all()
+void Compass::cancel_calibration_all()
 {
     _cancel_calibration_mask(0xFF);
 }
 
-bool
-Compass::_accept_calibration(uint8_t i)
+bool Compass::_accept_calibration(uint8_t i)
 {
     CompassCalibrator& cal = _calibrator[i];
     uint8_t cal_status = cal.get_status();
@@ -168,8 +161,7 @@ Compass::_accept_calibration(uint8_t i)
     }
 }
 
-bool
-Compass::_accept_calibration_mask(uint8_t mask)
+bool Compass::_accept_calibration_mask(uint8_t mask)
 {
     bool success = true;
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
@@ -251,8 +243,7 @@ void Compass::send_mag_cal_report(mavlink_channel_t chan)
     }
 }
 
-bool
-Compass::is_calibrating() const
+bool Compass::is_calibrating() const
 {
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
         switch(_calibrator[i].get_status()) {
@@ -268,8 +259,7 @@ Compass::is_calibrating() const
     return false;
 }
 
-uint8_t
-Compass::_get_cal_mask() const
+uint8_t Compass::_get_cal_mask() const
 {
     uint8_t cal_mask = 0;
     for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
@@ -279,7 +269,6 @@ Compass::_get_cal_mask() const
     }
     return cal_mask;
 }
-
 
 /*
   handle an incoming MAG_CAL command
@@ -314,32 +303,32 @@ MAV_RESULT Compass::handle_mag_cal_command(const mavlink_command_long_t &packet)
                 result = MAV_RESULT_FAILED;
             }
         }
-        
+
         break;
     }
 
     case MAV_CMD_DO_ACCEPT_MAG_CAL: {
         result = MAV_RESULT_ACCEPTED;
-        if(packet.param1 < 0 || packet.param1 > 255) {
+        if (packet.param1 < 0 || packet.param1 > 255) {
             result = MAV_RESULT_FAILED;
             break;
         }
-        
+
         uint8_t mag_mask = packet.param1;
-        
+
         if (mag_mask == 0) { // 0 means all
             mag_mask = 0xFF;
         }
-        
-        if(!_accept_calibration_mask(mag_mask)) {
+
+        if (!_accept_calibration_mask(mag_mask)) {
             result = MAV_RESULT_FAILED;
         }
         break;
     }
-        
+
     case MAV_CMD_DO_CANCEL_MAG_CAL: {
         result = MAV_RESULT_ACCEPTED;
-        if(packet.param1 < 0 || packet.param1 > 255) {
+        if (packet.param1 < 0 || packet.param1 > 255) {
             result = MAV_RESULT_FAILED;
             break;
         }

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -247,8 +247,7 @@ void Compass::send_mag_cal_report(mavlink_channel_t chan)
                 offdiag.x, offdiag.y, offdiag.z,
                 _calibrator[compass_id].get_orientation_confidence(),
                 _calibrator[compass_id].get_original_orientation(),
-                _calibrator[compass_id].get_orientation(),
-                scale_factor
+                _calibrator[compass_id].get_orientation()
             );
         }
     }

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -202,8 +202,8 @@ Compass::send_mag_cal_progress(mavlink_channel_t chan)
             cal_status == COMPASS_CAL_RUNNING_STEP_ONE ||
             cal_status == COMPASS_CAL_RUNNING_STEP_TWO) {
             uint8_t completion_pct = calibrator.get_completion_percent();
-            auto& completion_mask = calibrator.get_completion_mask();
-            Vector3f direction(0.0f,0.0f,0.0f);
+            const CompassCalibrator::completion_mask_t& completion_mask = calibrator.get_completion_mask();
+            const Vector3f direction;
             uint8_t attempt = _calibrator[compass_id].get_attempt();
 
             mavlink_msg_mag_cal_progress_send(

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -113,7 +113,7 @@ void Compass::_cancel_calibration(uint8_t i)
         AP_Notify::events.compass_cal_canceled = 1;
     }
     _cal_saved[i] = false;
-    _calibrator[i].clear();
+    _calibrator[i].stop();
 }
 
 void Compass::_cancel_calibration_mask(uint8_t mask)
@@ -169,7 +169,7 @@ bool Compass::_accept_calibration_mask(uint8_t mask)
             if (!_accept_calibration(i)) {
                 success = false;
             }
-            _calibrator[i].clear();
+            _calibrator[i].stop();
         }
     }
 

--- a/libraries/AP_Compass/AP_Compass_Calibration.cpp
+++ b/libraries/AP_Compass/AP_Compass_Calibration.cpp
@@ -142,11 +142,13 @@ bool Compass::_accept_calibration(uint8_t i)
         _cal_saved[i] = true;
 
         Vector3f ofs, diag, offdiag;
-        cal.get_calibration(ofs, diag, offdiag);
+        float scale_factor;
+        cal.get_calibration(ofs, diag, offdiag, scale_factor);
 
         set_and_save_offsets(i, ofs);
         set_and_save_diagonals(i,diag);
         set_and_save_offdiagonals(i,offdiag);
+        set_and_save_scale_factor(i,scale_factor);
 
         if (_state[i].external && _rotate_auto >= 2) {
             _state[i].orientation.set_and_save_ifchanged(cal.get_orientation());
@@ -224,7 +226,8 @@ void Compass::send_mag_cal_report(mavlink_channel_t chan)
             cal_status == COMPASS_CAL_BAD_ORIENTATION) {
             float fitness = _calibrator[compass_id].get_fitness();
             Vector3f ofs, diag, offdiag;
-            _calibrator[compass_id].get_calibration(ofs, diag, offdiag);
+            float scale_factor;
+            _calibrator[compass_id].get_calibration(ofs, diag, offdiag, scale_factor);
             uint8_t autosaved = _cal_saved[compass_id];
 
             mavlink_msg_mag_cal_report_send(
@@ -237,7 +240,8 @@ void Compass::send_mag_cal_report(mavlink_channel_t chan)
                 offdiag.x, offdiag.y, offdiag.z,
                 _calibrator[compass_id].get_orientation_confidence(),
                 _calibrator[compass_id].get_original_orientation(),
-                _calibrator[compass_id].get_orientation()
+                _calibrator[compass_id].get_orientation(),
+                scale_factor
             );
         }
     }

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -114,6 +114,11 @@ void AP_Compass_SITL::_timer()
         if (i == 0) {
             // rotate the first compass, allowing for testing of external compass rotation
             f.rotate_inverse((enum Rotation)_sitl->mag_orient.get());
+
+            f.rotate(get_board_orientation());
+
+            // scale the first compass to simulate sensor scale factor errors
+            f *= _sitl->mag_scaling;
         }
         rotate_field(f, _compass_instance[i]);
         publish_raw_field(f, _compass_instance[i]);

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -115,8 +115,6 @@ void AP_Compass_SITL::_timer()
             // rotate the first compass, allowing for testing of external compass rotation
             f.rotate_inverse((enum Rotation)_sitl->mag_orient.get());
 
-            f.rotate(get_board_orientation());
-
             // scale the first compass to simulate sensor scale factor errors
             f *= _sitl->mag_scaling;
         }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -461,11 +461,6 @@ float CompassCalibrator::calc_residual(const Vector3f& sample, const param_t& pa
     return params.radius - (softiron*(sample+params.offset)).length();
 }
 
-float CompassCalibrator::calc_mean_squared_residuals() const
-{
-    return calc_mean_squared_residuals(_params);
-}
-
 // calc the fitness given a set of parameters (offsets, diagonals, off diagonals)
 float CompassCalibrator::calc_mean_squared_residuals(const param_t& params) const
 {

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -73,10 +73,10 @@ CompassCalibrator::CompassCalibrator():
     _tolerance(COMPASS_CAL_DEFAULT_TOLERANCE),
     _sample_buffer(nullptr)
 {
-    clear();
+    stop();
 }
 
-void CompassCalibrator::clear()
+void CompassCalibrator::stop()
 {
     set_status(COMPASS_CAL_NOT_STARTED);
 }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -203,8 +203,9 @@ void CompassCalibrator::update(bool &failure)
             if (is_equal(_fitness, _initial_fitness) || isnan(_fitness)) {  // if true, means that fitness is diverging instead of converging
                 set_status(COMPASS_CAL_FAILED);
                 failure = true;
+            } else {
+                set_status(COMPASS_CAL_RUNNING_STEP_TWO);
             }
-            set_status(COMPASS_CAL_RUNNING_STEP_TWO);
         } else {
             if (_fit_step == 0) {
                 calc_initial_offset();

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -153,7 +153,7 @@ void CompassCalibrator::update_completion_mask(const Vector3f& v)
     _completion_mask[section / 8] |= 1 << (section % 8);
 }
 
-// reset and updated the completion mask using all samples in the sample buffer
+// reset and update the completion mask using all samples in the sample buffer
 void CompassCalibrator::update_completion_mask()
 {
     memset(_completion_mask, 0, sizeof(_completion_mask));

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -147,11 +147,6 @@ void CompassCalibrator::update_completion_mask()
     }
 }
 
-CompassCalibrator::completion_mask_t& CompassCalibrator::get_completion_mask()
-{
-    return _completion_mask;
-}
-
 bool CompassCalibrator::check_for_timeout() {
     uint32_t tnow = AP_HAL::millis();
     if(running() && tnow - _last_sample_ms > 1000) {

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -70,19 +70,20 @@ extern const AP_HAL::HAL& hal;
 ////////////////////////////////////////////////////////////
 
 CompassCalibrator::CompassCalibrator():
-_tolerance(COMPASS_CAL_DEFAULT_TOLERANCE),
-_sample_buffer(nullptr)
+    _tolerance(COMPASS_CAL_DEFAULT_TOLERANCE),
+    _sample_buffer(nullptr)
 {
     clear();
 }
 
-void CompassCalibrator::clear() {
+void CompassCalibrator::clear()
+{
     set_status(COMPASS_CAL_NOT_STARTED);
 }
 
 void CompassCalibrator::start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx)
 {
-    if(running()) {
+    if (running()) {
         return;
     }
     _offset_max = offset_max;
@@ -94,7 +95,8 @@ void CompassCalibrator::start(bool retry, float delay, uint16_t offset_max, uint
     set_status(COMPASS_CAL_WAITING_TO_START);
 }
 
-void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals) {
+void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals)
+{
     if (_status != COMPASS_CAL_SUCCESS) {
         return;
     }
@@ -104,10 +106,11 @@ void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, 
     offdiagonals = _params.offdiag;
 }
 
-float CompassCalibrator::get_completion_percent() const {
+float CompassCalibrator::get_completion_percent() const
+{
     // first sampling step is 1/3rd of the progress bar
     // never return more than 99% unless _status is COMPASS_CAL_SUCCESS
-    switch(_status) {
+    switch (_status) {
         case COMPASS_CAL_NOT_STARTED:
         case COMPASS_CAL_WAITING_TO_START:
             return 0.0f;
@@ -126,7 +129,7 @@ float CompassCalibrator::get_completion_percent() const {
 
 void CompassCalibrator::update_completion_mask(const Vector3f& v)
 {
-    Matrix3f softiron{
+    Matrix3f softiron {
         _params.diag.x,    _params.offdiag.x, _params.offdiag.y,
         _params.offdiag.x, _params.diag.y,    _params.offdiag.z,
         _params.offdiag.y, _params.offdiag.z, _params.diag.z
@@ -147,9 +150,10 @@ void CompassCalibrator::update_completion_mask()
     }
 }
 
-bool CompassCalibrator::check_for_timeout() {
+bool CompassCalibrator::check_for_timeout()
+{
     uint32_t tnow = AP_HAL::millis();
-    if(running() && tnow - _last_sample_ms > 1000) {
+    if (running() && tnow - _last_sample_ms > 1000) {
         _retry = false;
         set_status(COMPASS_CAL_FAILED);
         return true;
@@ -157,14 +161,15 @@ bool CompassCalibrator::check_for_timeout() {
     return false;
 }
 
-void CompassCalibrator::new_sample(const Vector3f& sample) {
+void CompassCalibrator::new_sample(const Vector3f& sample)
+{
     _last_sample_ms = AP_HAL::millis();
 
-    if(_status == COMPASS_CAL_WAITING_TO_START) {
+    if (_status == COMPASS_CAL_WAITING_TO_START) {
         set_status(COMPASS_CAL_RUNNING_STEP_ONE);
     }
 
-    if(running() && _samples_collected < COMPASS_CAL_NUM_SAMPLES && accept_sample(sample)) {
+    if (running() && _samples_collected < COMPASS_CAL_NUM_SAMPLES && accept_sample(sample)) {
         update_completion_mask(sample);
         _sample_buffer[_samples_collected].set(sample);
         _sample_buffer[_samples_collected].att.set_from_ahrs();
@@ -172,16 +177,17 @@ void CompassCalibrator::new_sample(const Vector3f& sample) {
     }
 }
 
-void CompassCalibrator::update(bool &failure) {
+void CompassCalibrator::update(bool &failure)
+{
     failure = false;
 
-    if(!fitting()) {
+    if (!fitting()) {
         return;
     }
 
-    if(_status == COMPASS_CAL_RUNNING_STEP_ONE) {
+    if (_status == COMPASS_CAL_RUNNING_STEP_ONE) {
         if (_fit_step >= 10) {
-            if(is_equal(_fitness,_initial_fitness) || isnan(_fitness)) {           //if true, means that fitness is diverging instead of converging
+            if (is_equal(_fitness, _initial_fitness) || isnan(_fitness)) {  // if true, means that fitness is diverging instead of converging
                 set_status(COMPASS_CAL_FAILED);
                 failure = true;
             }
@@ -193,9 +199,9 @@ void CompassCalibrator::update(bool &failure) {
             run_sphere_fit();
             _fit_step++;
         }
-    } else if(_status == COMPASS_CAL_RUNNING_STEP_TWO) {
+    } else if (_status == COMPASS_CAL_RUNNING_STEP_TWO) {
         if (_fit_step >= 35) {
-            if(fit_acceptable() && calculate_orientation()) {
+            if (fit_acceptable() && calculate_orientation()) {
                 set_status(COMPASS_CAL_SUCCESS);
             } else {
                 set_status(COMPASS_CAL_FAILED);
@@ -214,15 +220,18 @@ void CompassCalibrator::update(bool &failure) {
 /////////////////////////////////////////////////////////////
 ////////////////////// PRIVATE METHODS //////////////////////
 /////////////////////////////////////////////////////////////
-bool CompassCalibrator::running() const {
+bool CompassCalibrator::running() const
+{
     return _status == COMPASS_CAL_RUNNING_STEP_ONE || _status == COMPASS_CAL_RUNNING_STEP_TWO;
 }
 
-bool CompassCalibrator::fitting() const {
-    return running() && _samples_collected == COMPASS_CAL_NUM_SAMPLES;
+bool CompassCalibrator::fitting() const
+{
+    return running() && (_samples_collected == COMPASS_CAL_NUM_SAMPLES);
 }
 
-void CompassCalibrator::initialize_fit() {
+void CompassCalibrator::initialize_fit()
+{
     //initialize _fitness before starting a fit
     if (_samples_collected != 0) {
         _fitness = calc_mean_squared_residuals(_params);
@@ -235,7 +244,8 @@ void CompassCalibrator::initialize_fit() {
     _fit_step = 0;
 }
 
-void CompassCalibrator::reset_state() {
+void CompassCalibrator::reset_state()
+{
     _samples_collected = 0;
     _samples_thinned = 0;
     _params.radius = 200;
@@ -247,17 +257,17 @@ void CompassCalibrator::reset_state() {
     initialize_fit();
 }
 
-bool CompassCalibrator::set_status(compass_cal_status_t status) {
+bool CompassCalibrator::set_status(compass_cal_status_t status)
+{
     if (status != COMPASS_CAL_NOT_STARTED && _status == status) {
         return true;
     }
 
-    switch(status) {
+    switch (status) {
         case COMPASS_CAL_NOT_STARTED:
             reset_state();
             _status = COMPASS_CAL_NOT_STARTED;
-
-            if(_sample_buffer != nullptr) {
+            if (_sample_buffer != nullptr) {
                 free(_sample_buffer);
                 _sample_buffer = nullptr;
             }
@@ -266,34 +276,30 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
         case COMPASS_CAL_WAITING_TO_START:
             reset_state();
             _status = COMPASS_CAL_WAITING_TO_START;
-
             set_status(COMPASS_CAL_RUNNING_STEP_ONE);
             return true;
 
         case COMPASS_CAL_RUNNING_STEP_ONE:
-            if(_status != COMPASS_CAL_WAITING_TO_START) {
+            if (_status != COMPASS_CAL_WAITING_TO_START) {
                 return false;
             }
 
-            if(_attempt == 1 && (AP_HAL::millis()-_start_time_ms)*1.0e-3f < _delay_start_sec) {
+            if (_attempt == 1 && (AP_HAL::millis()-_start_time_ms)*1.0e-3f < _delay_start_sec) {
                 return false;
             }
 
             if (_sample_buffer == nullptr) {
-                _sample_buffer =
-                    (CompassSample*) calloc(COMPASS_CAL_NUM_SAMPLES, sizeof(CompassSample));
+                _sample_buffer = (CompassSample*)calloc(COMPASS_CAL_NUM_SAMPLES, sizeof(CompassSample));
             }
-
-            if(_sample_buffer != nullptr) {
+            if (_sample_buffer != nullptr) {
                 initialize_fit();
                 _status = COMPASS_CAL_RUNNING_STEP_ONE;
                 return true;
             }
-
             return false;
 
         case COMPASS_CAL_RUNNING_STEP_TWO:
-            if(_status != COMPASS_CAL_RUNNING_STEP_ONE) {
+            if (_status != COMPASS_CAL_RUNNING_STEP_ONE) {
                 return false;
             }
             thin_samples();
@@ -302,11 +308,11 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
             return true;
 
         case COMPASS_CAL_SUCCESS:
-            if(_status != COMPASS_CAL_RUNNING_STEP_TWO) {
+            if (_status != COMPASS_CAL_RUNNING_STEP_TWO) {
                 return false;
             }
 
-            if(_sample_buffer != nullptr) {
+            if (_sample_buffer != nullptr) {
                 free(_sample_buffer);
                 _sample_buffer = nullptr;
             }
@@ -322,30 +328,31 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
             FALLTHROUGH;
             
         case COMPASS_CAL_BAD_ORIENTATION:
-            if(_status == COMPASS_CAL_NOT_STARTED) {
+            if (_status == COMPASS_CAL_NOT_STARTED) {
                 return false;
             }
 
-            if(_retry && set_status(COMPASS_CAL_WAITING_TO_START)) {
+            if (_retry && set_status(COMPASS_CAL_WAITING_TO_START)) {
                 _attempt++;
                 return true;
             }
 
-            if(_sample_buffer != nullptr) {
+            if (_sample_buffer != nullptr) {
                 free(_sample_buffer);
                 _sample_buffer = nullptr;
             }
 
             _status = status;
             return true;
-            
+
         default:
             return false;
     };
 }
 
-bool CompassCalibrator::fit_acceptable() {
-    if( !isnan(_fitness) &&
+bool CompassCalibrator::fit_acceptable()
+{
+    if (!isnan(_fitness) &&
         _params.radius > 150 && _params.radius < 950 && //Earth's magnetic field strength range: 250-850mG
         fabsf(_params.offset.x) < _offset_max &&
         fabsf(_params.offset.y) < _offset_max &&
@@ -353,35 +360,35 @@ bool CompassCalibrator::fit_acceptable() {
         _params.diag.x > 0.2f && _params.diag.x < 5.0f &&
         _params.diag.y > 0.2f && _params.diag.y < 5.0f &&
         _params.diag.z > 0.2f && _params.diag.z < 5.0f &&
-        fabsf(_params.offdiag.x) <  1.0f &&      //absolute of sine/cosine output cannot be greater than 1
-        fabsf(_params.offdiag.y) <  1.0f &&
-        fabsf(_params.offdiag.z) <  1.0f ){
-
+        fabsf(_params.offdiag.x) < 1.0f &&      //absolute of sine/cosine output cannot be greater than 1
+        fabsf(_params.offdiag.y) < 1.0f &&
+        fabsf(_params.offdiag.z) < 1.0f ) {
             return _fitness <= sq(_tolerance);
         }
     return false;
 }
 
-void CompassCalibrator::thin_samples() {
-    if(_sample_buffer == nullptr) {
+void CompassCalibrator::thin_samples()
+{
+    if (_sample_buffer == nullptr) {
         return;
     }
 
     _samples_thinned = 0;
     // shuffle the samples http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
     // this is so that adjacent samples don't get sequentially eliminated
-    for(uint16_t i=_samples_collected-1; i>=1; i--) {
+    for (uint16_t i=_samples_collected-1; i>=1; i--) {
         uint16_t j = get_random16() % (i+1);
         CompassSample temp = _sample_buffer[i];
         _sample_buffer[i] = _sample_buffer[j];
         _sample_buffer[j] = temp;
     }
 
-    for(uint16_t i=0; i < _samples_collected; i++) {
-        if(!accept_sample(_sample_buffer[i])) {
+    for (uint16_t i=0; i < _samples_collected; i++) {
+        if (!accept_sample(_sample_buffer[i])) {
             _sample_buffer[i] = _sample_buffer[_samples_collected-1];
-            _samples_collected --;
-            _samples_thinned ++;
+            _samples_collected--;
+            _samples_thinned++;
         }
     }
 
@@ -410,26 +417,28 @@ bool CompassCalibrator::accept_sample(const Vector3f& sample)
     static const float a = (4.0f * M_PI / (3.0f * faces)) + M_PI / 3.0f;
     static const float theta = 0.5f * acosf(cosf(a) / (1.0f - cosf(a)));
 
-    if(_sample_buffer == nullptr) {
+    if (_sample_buffer == nullptr) {
         return false;
     }
 
     float min_distance = _params.radius * 2*sinf(theta/2);
 
-    for (uint16_t i = 0; i<_samples_collected; i++){
+    for (uint16_t i = 0; i<_samples_collected; i++) {
         float distance = (sample - _sample_buffer[i].get()).length();
-        if(distance < min_distance) {
+        if (distance < min_distance) {
             return false;
         }
     }
     return true;
 }
 
-bool CompassCalibrator::accept_sample(const CompassSample& sample) {
+bool CompassCalibrator::accept_sample(const CompassSample& sample)
+{
     return accept_sample(sample.get());
 }
 
-float CompassCalibrator::calc_residual(const Vector3f& sample, const param_t& params) const {
+float CompassCalibrator::calc_residual(const Vector3f& sample, const param_t& params) const
+{
     Matrix3f softiron(
         params.diag.x    , params.offdiag.x , params.offdiag.y,
         params.offdiag.x , params.diag.y    , params.offdiag.z,
@@ -445,11 +454,11 @@ float CompassCalibrator::calc_mean_squared_residuals() const
 
 float CompassCalibrator::calc_mean_squared_residuals(const param_t& params) const
 {
-    if(_sample_buffer == nullptr || _samples_collected == 0) {
+    if (_sample_buffer == nullptr || _samples_collected == 0) {
         return 1.0e30f;
     }
     float sum = 0.0f;
-    for(uint16_t i=0; i < _samples_collected; i++){
+    for (uint16_t i=0; i < _samples_collected; i++) {
         Vector3f sample = _sample_buffer[i].get();
         float resid = calc_residual(sample, params);
         sum += sq(resid);
@@ -458,7 +467,8 @@ float CompassCalibrator::calc_mean_squared_residuals(const param_t& params) cons
     return sum;
 }
 
-void CompassCalibrator::calc_sphere_jacob(const Vector3f& sample, const param_t& params, float* ret) const{
+void CompassCalibrator::calc_sphere_jacob(const Vector3f& sample, const param_t& params, float* ret) const
+{
     const Vector3f &offset = params.offset;
     const Vector3f &diag = params.diag;
     const Vector3f &offdiag = params.offdiag;
@@ -485,7 +495,7 @@ void CompassCalibrator::calc_initial_offset()
 {
     // Set initial offset to the average value of the samples
     _params.offset.zero();
-    for(uint16_t k = 0; k<_samples_collected; k++) {
+    for (uint16_t k = 0; k<_samples_collected; k++) {
         _params.offset -= _sample_buffer[k].get();
     }
     _params.offset /= _samples_collected;
@@ -493,7 +503,7 @@ void CompassCalibrator::calc_initial_offset()
 
 void CompassCalibrator::run_sphere_fit()
 {
-    if(_sample_buffer == nullptr) {
+    if (_sample_buffer == nullptr) {
         return;
     }
 
@@ -509,16 +519,16 @@ void CompassCalibrator::run_sphere_fit()
     float JTFI[COMPASS_CAL_NUM_SPHERE_PARAMS] = { };
 
     // Gauss Newton Part common for all kind of extensions including LM
-    for(uint16_t k = 0; k<_samples_collected; k++) {
+    for (uint16_t k = 0; k<_samples_collected; k++) {
         Vector3f sample = _sample_buffer[k].get();
 
         float sphere_jacob[COMPASS_CAL_NUM_SPHERE_PARAMS];
 
         calc_sphere_jacob(sample, fit1_params, sphere_jacob);
 
-        for(uint8_t i = 0;i < COMPASS_CAL_NUM_SPHERE_PARAMS; i++) {
+        for (uint8_t i = 0;i < COMPASS_CAL_NUM_SPHERE_PARAMS; i++) {
             // compute JTJ
-            for(uint8_t j = 0; j < COMPASS_CAL_NUM_SPHERE_PARAMS; j++) {
+            for (uint8_t j = 0; j < COMPASS_CAL_NUM_SPHERE_PARAMS; j++) {
                 JTJ[i*COMPASS_CAL_NUM_SPHERE_PARAMS+j] += sphere_jacob[i] * sphere_jacob[j];
                 JTJ2[i*COMPASS_CAL_NUM_SPHERE_PARAMS+j] += sphere_jacob[i] * sphere_jacob[j];   //a backup JTJ for LM
             }
@@ -527,24 +537,23 @@ void CompassCalibrator::run_sphere_fit()
         }
     }
 
-
     //------------------------Levenberg-Marquardt-part-starts-here---------------------------------//
     //refer: http://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm#Choice_of_damping_parameter
-    for(uint8_t i = 0; i < COMPASS_CAL_NUM_SPHERE_PARAMS; i++) {
+    for (uint8_t i = 0; i < COMPASS_CAL_NUM_SPHERE_PARAMS; i++) {
         JTJ[i*COMPASS_CAL_NUM_SPHERE_PARAMS+i] += _sphere_lambda;
         JTJ2[i*COMPASS_CAL_NUM_SPHERE_PARAMS+i] += _sphere_lambda/lma_damping;
     }
 
-    if(!inverse(JTJ, JTJ, 4)) {
+    if (!inverse(JTJ, JTJ, 4)) {
         return;
     }
 
-    if(!inverse(JTJ2, JTJ2, 4)) {
+    if (!inverse(JTJ2, JTJ2, 4)) {
         return;
     }
 
-    for(uint8_t row=0; row < COMPASS_CAL_NUM_SPHERE_PARAMS; row++) {
-        for(uint8_t col=0; col < COMPASS_CAL_NUM_SPHERE_PARAMS; col++) {
+    for (uint8_t row=0; row < COMPASS_CAL_NUM_SPHERE_PARAMS; row++) {
+        for (uint8_t col=0; col < COMPASS_CAL_NUM_SPHERE_PARAMS; col++) {
             fit1_params.get_sphere_params()[row] -= JTFI[col] * JTJ[row*COMPASS_CAL_NUM_SPHERE_PARAMS+col];
             fit2_params.get_sphere_params()[row] -= JTFI[col] * JTJ2[row*COMPASS_CAL_NUM_SPHERE_PARAMS+col];
         }
@@ -553,27 +562,26 @@ void CompassCalibrator::run_sphere_fit()
     fit1 = calc_mean_squared_residuals(fit1_params);
     fit2 = calc_mean_squared_residuals(fit2_params);
 
-    if(fit1 > _fitness && fit2 > _fitness){
+    if (fit1 > _fitness && fit2 > _fitness) {
         _sphere_lambda *= lma_damping;
-    } else if(fit2 < _fitness && fit2 < fit1) {
+    } else if (fit2 < _fitness && fit2 < fit1) {
         _sphere_lambda /= lma_damping;
         fit1_params = fit2_params;
         fitness = fit2;
-    } else if(fit1 < _fitness){
+    } else if (fit1 < _fitness) {
         fitness = fit1;
     }
     //--------------------Levenberg-Marquardt-part-ends-here--------------------------------//
 
-    if(!isnan(fitness) && fitness < _fitness) {
+    if (!isnan(fitness) && fitness < _fitness) {
         _fitness = fitness;
         _params = fit1_params;
         update_completion_mask();
     }
 }
 
-
-
-void CompassCalibrator::calc_ellipsoid_jacob(const Vector3f& sample, const param_t& params, float* ret) const{
+void CompassCalibrator::calc_ellipsoid_jacob(const Vector3f& sample, const param_t& params, float* ret) const
+{
     const Vector3f &offset = params.offset;
     const Vector3f &diag = params.diag;
     const Vector3f &offdiag = params.offdiag;
@@ -604,34 +612,32 @@ void CompassCalibrator::calc_ellipsoid_jacob(const Vector3f& sample, const param
 
 void CompassCalibrator::run_ellipsoid_fit()
 {
-    if(_sample_buffer == nullptr) {
+    if (_sample_buffer == nullptr) {
         return;
     }
 
     const float lma_damping = 10.0f;
-
 
     float fitness = _fitness;
     float fit1, fit2;
     param_t fit1_params, fit2_params;
     fit1_params = fit2_params = _params;
 
-
     float JTJ[COMPASS_CAL_NUM_ELLIPSOID_PARAMS*COMPASS_CAL_NUM_ELLIPSOID_PARAMS] = { };
     float JTJ2[COMPASS_CAL_NUM_ELLIPSOID_PARAMS*COMPASS_CAL_NUM_ELLIPSOID_PARAMS] = { };
     float JTFI[COMPASS_CAL_NUM_ELLIPSOID_PARAMS] = { };
 
     // Gauss Newton Part common for all kind of extensions including LM
-    for(uint16_t k = 0; k<_samples_collected; k++) {
+    for (uint16_t k = 0; k<_samples_collected; k++) {
         Vector3f sample = _sample_buffer[k].get();
 
         float ellipsoid_jacob[COMPASS_CAL_NUM_ELLIPSOID_PARAMS];
 
         calc_ellipsoid_jacob(sample, fit1_params, ellipsoid_jacob);
 
-        for(uint8_t i = 0;i < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; i++) {
+        for (uint8_t i = 0;i < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; i++) {
             // compute JTJ
-            for(uint8_t j = 0; j < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; j++) {
+            for (uint8_t j = 0; j < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; j++) {
                 JTJ [i*COMPASS_CAL_NUM_ELLIPSOID_PARAMS+j] += ellipsoid_jacob[i] * ellipsoid_jacob[j];
                 JTJ2[i*COMPASS_CAL_NUM_ELLIPSOID_PARAMS+j] += ellipsoid_jacob[i] * ellipsoid_jacob[j];
             }
@@ -640,25 +646,23 @@ void CompassCalibrator::run_ellipsoid_fit()
         }
     }
 
-
-
     //------------------------Levenberg-Marquardt-part-starts-here---------------------------------//
     //refer: http://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm#Choice_of_damping_parameter
-    for(uint8_t i = 0; i < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; i++) {
+    for (uint8_t i = 0; i < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; i++) {
         JTJ[i*COMPASS_CAL_NUM_ELLIPSOID_PARAMS+i] += _ellipsoid_lambda;
         JTJ2[i*COMPASS_CAL_NUM_ELLIPSOID_PARAMS+i] += _ellipsoid_lambda/lma_damping;
     }
 
-    if(!inverse(JTJ, JTJ, 9)) {
+    if (!inverse(JTJ, JTJ, 9)) {
         return;
     }
 
-    if(!inverse(JTJ2, JTJ2, 9)) {
+    if (!inverse(JTJ2, JTJ2, 9)) {
         return;
     }
 
-    for(uint8_t row=0; row < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; row++) {
-        for(uint8_t col=0; col < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; col++) {
+    for (uint8_t row=0; row < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; row++) {
+        for (uint8_t col=0; col < COMPASS_CAL_NUM_ELLIPSOID_PARAMS; col++) {
             fit1_params.get_ellipsoid_params()[row] -= JTFI[col] * JTJ[row*COMPASS_CAL_NUM_ELLIPSOID_PARAMS+col];
             fit2_params.get_ellipsoid_params()[row] -= JTFI[col] * JTJ2[row*COMPASS_CAL_NUM_ELLIPSOID_PARAMS+col];
         }
@@ -667,18 +671,18 @@ void CompassCalibrator::run_ellipsoid_fit()
     fit1 = calc_mean_squared_residuals(fit1_params);
     fit2 = calc_mean_squared_residuals(fit2_params);
 
-    if(fit1 > _fitness && fit2 > _fitness){
+    if (fit1 > _fitness && fit2 > _fitness) {
         _ellipsoid_lambda *= lma_damping;
-    } else if(fit2 < _fitness && fit2 < fit1) {
+    } else if (fit2 < _fitness && fit2 < fit1) {
         _ellipsoid_lambda /= lma_damping;
         fit1_params = fit2_params;
         fitness = fit2;
-    } else if(fit1 < _fitness){
+    } else if (fit1 < _fitness) {
         fitness = fit1;
     }
     //--------------------Levenberg-part-ends-here--------------------------------//
 
-    if(fitness < _fitness) {
+    if (fitness < _fitness) {
         _fitness = fitness;
         _params = fit1_params;
         update_completion_mask();
@@ -693,20 +697,22 @@ void CompassCalibrator::run_ellipsoid_fit()
 #define COMPASS_CAL_SAMPLE_SCALE_TO_FIXED(__X) ((int16_t)constrain_float(roundf(__X*8.0f), INT16_MIN, INT16_MAX))
 #define COMPASS_CAL_SAMPLE_SCALE_TO_FLOAT(__X) (__X/8.0f)
 
-Vector3f CompassCalibrator::CompassSample::get() const {
+Vector3f CompassCalibrator::CompassSample::get() const
+{
     return Vector3f(COMPASS_CAL_SAMPLE_SCALE_TO_FLOAT(x),
                     COMPASS_CAL_SAMPLE_SCALE_TO_FLOAT(y),
                     COMPASS_CAL_SAMPLE_SCALE_TO_FLOAT(z));
 }
 
-void CompassCalibrator::CompassSample::set(const Vector3f &in) {
+void CompassCalibrator::CompassSample::set(const Vector3f &in)
+{
     x = COMPASS_CAL_SAMPLE_SCALE_TO_FIXED(in.x);
     y = COMPASS_CAL_SAMPLE_SCALE_TO_FIXED(in.y);
     z = COMPASS_CAL_SAMPLE_SCALE_TO_FIXED(in.z);
 }
 
-
-void CompassCalibrator::AttitudeSample::set_from_ahrs(void) {
+void CompassCalibrator::AttitudeSample::set_from_ahrs(void)
+{
     const Matrix3f &dcm = AP::ahrs().get_DCM_rotation_body_to_ned();
     float roll_rad, pitch_rad, yaw_rad;
     dcm.to_euler(&roll_rad, &pitch_rad, &yaw_rad);
@@ -715,7 +721,8 @@ void CompassCalibrator::AttitudeSample::set_from_ahrs(void) {
     yaw = constrain_int16(127 * (yaw_rad / M_PI), -127, 127);
 }
 
-Matrix3f CompassCalibrator::AttitudeSample::get_rotmat(void) {
+Matrix3f CompassCalibrator::AttitudeSample::get_rotmat(void)
+{
     float roll_rad, pitch_rad, yaw_rad;
     roll_rad = roll * (M_PI / 127);
     pitch_rad = pitch * (M_PI_2 / 127);
@@ -751,7 +758,7 @@ Vector3f CompassCalibrator::calculate_earth_field(CompassSample &sample, enum Ro
     rot_offsets.rotate_inverse(_orientation);
 
     rot_offsets.rotate(r);
-    
+
     v += rot_offsets;
 
     // rotate the sample from body frame back to earth frame
@@ -808,7 +815,7 @@ bool CompassCalibrator::calculate_orientation(void)
     // consider this a pass if the best orientation is 2x better
     // variance than 2nd best
     const float variance_threshold = 2.0;
-    
+
     float second_best = besti==ROTATION_NONE?variance[1]:variance[0];
     enum Rotation besti2 = ROTATION_NONE;
     for (enum Rotation r = ROTATION_NONE; r<ROTATION_MAX; r = (enum Rotation)(r+1)) {
@@ -821,7 +828,7 @@ bool CompassCalibrator::calculate_orientation(void)
     }
 
     _orientation_confidence = second_best/bestv;
-    
+
     bool pass;
     if (besti == _orientation) {
         // if the orientation matched then allow for a low threshold
@@ -858,7 +865,7 @@ bool CompassCalibrator::calculate_orientation(void)
         set_status(COMPASS_CAL_BAD_ORIENTATION);
         return false;
     }
-    
+
     // correct the offsets for the new orientation
     Vector3f rot_offsets = _params.offset;
     rot_offsets.rotate_inverse(_orientation);
@@ -880,6 +887,6 @@ bool CompassCalibrator::calculate_orientation(void)
     initialize_fit();
     run_sphere_fit();
     run_ellipsoid_fit();
-    
+
     return fit_acceptable();
 }

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -61,7 +61,11 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_GeodesicGrid.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_GPS/AP_GPS.h>
 #include <GCS_MAVLink/GCS.h>
+
+#define FIELD_RADIUS_MIN 150
+#define FIELD_RADIUS_MAX 950
 
 extern const AP_HAL::HAL& hal;
 
@@ -104,7 +108,7 @@ void CompassCalibrator::start(bool retry, float delay, uint16_t offset_max, uint
     set_status(COMPASS_CAL_WAITING_TO_START);
 }
 
-void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals)
+void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals, float &scale_factor)
 {
     if (_status != COMPASS_CAL_SUCCESS) {
         return;
@@ -113,6 +117,7 @@ void CompassCalibrator::get_calibration(Vector3f &offsets, Vector3f &diagonals, 
     offsets = _params.offset;
     diagonals = _params.diag;
     offdiagonals = _params.offdiag;
+    scale_factor = _params.scale_factor;
 }
 
 float CompassCalibrator::get_completion_percent() const
@@ -131,6 +136,7 @@ float CompassCalibrator::get_completion_percent() const
             return 100.0f;
         case COMPASS_CAL_FAILED:
         case COMPASS_CAL_BAD_ORIENTATION:
+        case COMPASS_CAL_BAD_RADIUS:
         default:
             return 0.0f;
     };
@@ -215,7 +221,7 @@ void CompassCalibrator::update(bool &failure)
         }
     } else if (_status == COMPASS_CAL_RUNNING_STEP_TWO) {
         if (_fit_step >= 35) {
-            if (fit_acceptable() && calculate_orientation()) {
+            if (fit_acceptable() && fix_radius() && calculate_orientation()) {
                 set_status(COMPASS_CAL_SUCCESS);
             } else {
                 set_status(COMPASS_CAL_FAILED);
@@ -266,6 +272,7 @@ void CompassCalibrator::reset_state()
     _params.offset.zero();
     _params.diag = Vector3f(1.0f,1.0f,1.0f);
     _params.offdiag.zero();
+    _params.scale_factor = 0;
 
     memset(_completion_mask, 0, sizeof(_completion_mask));
     initialize_fit();
@@ -336,13 +343,15 @@ bool CompassCalibrator::set_status(compass_cal_status_t status)
             return true;
 
         case COMPASS_CAL_FAILED:
-            if (_status == COMPASS_CAL_BAD_ORIENTATION) {
+            if (_status == COMPASS_CAL_BAD_ORIENTATION ||
+                _status == COMPASS_CAL_BAD_RADIUS) {
                 // don't overwrite bad orientation status
                 return false;
             }
             FALLTHROUGH;
             
         case COMPASS_CAL_BAD_ORIENTATION:
+        case COMPASS_CAL_BAD_RADIUS:
             if (_status == COMPASS_CAL_NOT_STARTED) {
                 return false;
             }
@@ -368,7 +377,7 @@ bool CompassCalibrator::set_status(compass_cal_status_t status)
 bool CompassCalibrator::fit_acceptable()
 {
     if (!isnan(_fitness) &&
-        _params.radius > 150 && _params.radius < 950 && //Earth's magnetic field strength range: 250-850mG
+        _params.radius > FIELD_RADIUS_MIN && _params.radius < FIELD_RADIUS_MAX &&
         fabsf(_params.offset.x) < _offset_max &&
         fabsf(_params.offset.y) < _offset_max &&
         fabsf(_params.offset.z) < _offset_max &&
@@ -919,4 +928,41 @@ bool CompassCalibrator::calculate_orientation(void)
     run_ellipsoid_fit();
 
     return fit_acceptable();
+}
+
+/*
+  fix radius of the fit to compensate for sensor scale factor errors
+  return false if radius is outside acceptable range
+ */
+bool CompassCalibrator::fix_radius(void)
+{
+    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
+        // we don't have a position, leave scale factor as 0. This
+        // will disable use of WMM in the EKF. Users can manually set
+        // scale factor after calibration if it is known
+        _params.scale_factor = 0;
+        return true;
+    }
+    const struct Location &loc = AP::gps().location();
+    float intensity;
+    float declination;
+    float inclination;
+    AP_Declination::get_mag_field_ef(loc.lat * 1e-7f, loc.lng * 1e-7f, intensity, declination, inclination);
+
+    float expected_radius = intensity * 1000; // mGauss
+    float correction = expected_radius / _params.radius;
+
+    if (correction > COMPASS_MAX_SCALE_FACTOR || correction < COMPASS_MIN_SCALE_FACTOR) {
+        // don't allow more than 30% scale factor correction
+        gcs().send_text(MAV_SEVERITY_ERROR, "Mag(%u) bad radius %.0f expected %.0f",
+                        _compass_idx,
+                        _params.radius,
+                        expected_radius);
+        set_status(COMPASS_CAL_BAD_RADIUS);
+        return false;
+    }
+
+    _params.scale_factor = correction;
+
+    return true;
 }

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -50,7 +50,7 @@ public:
     enum Rotation get_original_orientation() const { return _orig_orientation; }
 
     float get_completion_percent() const;
-    completion_mask_t& get_completion_mask();
+    const completion_mask_t& get_completion_mask() const { return _completion_mask; }
     enum compass_cal_status_t get_status() const { return _status; }
     float get_fitness() const { return sqrtf(_fitness); }
     float get_orientation_confidence() const { return _orientation_confidence; }

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -109,8 +109,8 @@ private:
     bool set_status(compass_cal_status_t status);
 
     // returns true if sample should be added to buffer
-    bool accept_sample(const Vector3f &sample);
-    bool accept_sample(const CompassSample &sample);
+    bool accept_sample(const Vector3f &sample, uint16_t skip_index = UINT16_MAX);
+    bool accept_sample(const CompassSample &sample, uint16_t skip_index = UINT16_MAX);
 
     // returns true if fit is acceptable
     bool fit_acceptable();

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -16,7 +16,11 @@ enum compass_cal_status_t {
     COMPASS_CAL_SUCCESS = 4,
     COMPASS_CAL_FAILED = 5,
     COMPASS_CAL_BAD_ORIENTATION = 6,
+    COMPASS_CAL_BAD_RADIUS = 7,
 };
+
+#define COMPASS_MIN_SCALE_FACTOR 0.3
+#define COMPASS_MAX_SCALE_FACTOR 1.6
 
 class CompassCalibrator {
 public:
@@ -45,7 +49,7 @@ public:
     enum compass_cal_status_t get_status() const { return _status; }
 
     // get calibration outputs (offsets, diagonals, offdiagonals) and fitness
-    void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);
+    void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals, float &scale_factor);
     float get_fitness() const { return sqrtf(_fitness); }
 
     // get corrected (and original) orientation
@@ -80,6 +84,7 @@ private:
         Vector3f offset;    // offsets
         Vector3f diag;      // diagonal scaling
         Vector3f offdiag;   // off diagonal scaling
+        float scale_factor; // scaling factor to compensate for radius error
     };
 
     // compact class for approximate attitude, to save memory
@@ -154,6 +159,9 @@ private:
     // calculate compass orientation
     Vector3f calculate_earth_field(CompassSample &sample, enum Rotation r);
     bool calculate_orientation();
+
+    // fix radius to compensate for sensor scaling errors
+    bool fix_radius();
 
     uint8_t _compass_idx;                   // index of the compass providing data
     enum compass_cal_status_t _status;      // current state of calibrator

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -10,13 +10,13 @@
 #define COMPASS_CAL_DEFAULT_TOLERANCE 5.0f
 
 enum compass_cal_status_t {
-    COMPASS_CAL_NOT_STARTED=0,
-    COMPASS_CAL_WAITING_TO_START=1,
-    COMPASS_CAL_RUNNING_STEP_ONE=2,
-    COMPASS_CAL_RUNNING_STEP_TWO=3,
-    COMPASS_CAL_SUCCESS=4,
-    COMPASS_CAL_FAILED=5,
-    COMPASS_CAL_BAD_ORIENTATION=6,
+    COMPASS_CAL_NOT_STARTED = 0,
+    COMPASS_CAL_WAITING_TO_START = 1,
+    COMPASS_CAL_RUNNING_STEP_ONE = 2,
+    COMPASS_CAL_RUNNING_STEP_TWO = 3,
+    COMPASS_CAL_SUCCESS = 4,
+    COMPASS_CAL_FAILED = 5,
+    COMPASS_CAL_BAD_ORIENTATION = 6,
 };
 
 class CompassCalibrator {
@@ -42,7 +42,7 @@ public:
         _is_external = is_external;
         _fix_orientation = fix_orientation;
     }
-    
+
     void set_tolerance(float tolerance) { _tolerance = tolerance; }
 
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -19,8 +19,8 @@ enum compass_cal_status_t {
     COMPASS_CAL_BAD_RADIUS = 7,
 };
 
-#define COMPASS_MIN_SCALE_FACTOR 0.3
-#define COMPASS_MAX_SCALE_FACTOR 1.6
+#define COMPASS_MIN_SCALE_FACTOR 0.85
+#define COMPASS_MAX_SCALE_FACTOR 1.3
 
 class CompassCalibrator {
 public:

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -46,8 +46,8 @@ public:
     void set_tolerance(float tolerance) { _tolerance = tolerance; }
 
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);
-    enum Rotation get_orientation(void) { return _orientation; }
-    enum Rotation get_original_orientation(void) { return _orig_orientation; }
+    enum Rotation get_orientation() const { return _orientation; }
+    enum Rotation get_original_orientation() const { return _orig_orientation; }
 
     float get_completion_percent() const;
     completion_mask_t& get_completion_mask();

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -133,7 +133,6 @@ private:
     // calc the fitness of the parameters (offsets, diagonals, off diagonals) vs all the samples collected
     // returns 1.0e30f if the sample buffer is empty
     float calc_mean_squared_residuals(const param_t& params) const;
-    float calc_mean_squared_residuals() const;
 
     // calculate initial offsets by simply taking the average values of the samples
     void calc_initial_offset();

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -30,7 +30,7 @@ public:
 
     // start or stop the calibration
     void start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx);
-    void clear();
+    void stop();
 
     // update the state machine and calculate offsets, diagonals and offdiagonals
     void update(bool &failure);

--- a/libraries/AP_Compass/CompassCalibrator.h
+++ b/libraries/AP_Compass/CompassCalibrator.h
@@ -2,13 +2,12 @@
 
 #include <AP_Math/AP_Math.h>
 
-#define COMPASS_CAL_NUM_SPHERE_PARAMS 4
-#define COMPASS_CAL_NUM_ELLIPSOID_PARAMS 9
-#define COMPASS_CAL_NUM_SAMPLES 300
+#define COMPASS_CAL_NUM_SPHERE_PARAMS       4
+#define COMPASS_CAL_NUM_ELLIPSOID_PARAMS    9
+#define COMPASS_CAL_NUM_SAMPLES             300     // number of samples required before fitting begins
+#define COMPASS_CAL_DEFAULT_TOLERANCE       5.0f    // default RMS tolerance
 
-//RMS tolerance
-#define COMPASS_CAL_DEFAULT_TOLERANCE 5.0f
-
+// compass calibration states
 enum compass_cal_status_t {
     COMPASS_CAL_NOT_STARTED = 0,
     COMPASS_CAL_WAITING_TO_START = 1,
@@ -21,42 +20,52 @@ enum compass_cal_status_t {
 
 class CompassCalibrator {
 public:
-    typedef uint8_t completion_mask_t[10];
-
     CompassCalibrator();
 
+    // set tolerance of calibration (aka fitness)
+    void set_tolerance(float tolerance) { _tolerance = tolerance; }
+
+    // set compass's initial orientation and whether it should be automatically fixed (if required)
+    void set_orientation(enum Rotation orientation, bool is_external, bool fix_orientation);
+
+    // start or stop the calibration
     void start(bool retry, float delay, uint16_t offset_max, uint8_t compass_idx);
     void clear();
 
+    // update the state machine and calculate offsets, diagonals and offdiagonals
     void update(bool &failure);
     void new_sample(const Vector3f &sample);
 
     bool check_for_timeout();
 
+    // running is true if actively calculating offsets, diagonals or offdiagonals
     bool running() const;
 
-    void set_orientation(enum Rotation orientation, bool is_external, bool fix_orientation) {
-        _check_orientation = true;
-        _orientation = orientation;
-        _orig_orientation = orientation;
-        _is_external = is_external;
-        _fix_orientation = fix_orientation;
-    }
+    // get status of calibrations progress
+    enum compass_cal_status_t get_status() const { return _status; }
 
-    void set_tolerance(float tolerance) { _tolerance = tolerance; }
-
+    // get calibration outputs (offsets, diagonals, offdiagonals) and fitness
     void get_calibration(Vector3f &offsets, Vector3f &diagonals, Vector3f &offdiagonals);
+    float get_fitness() const { return sqrtf(_fitness); }
+
+    // get corrected (and original) orientation
     enum Rotation get_orientation() const { return _orientation; }
     enum Rotation get_original_orientation() const { return _orig_orientation; }
-
-    float get_completion_percent() const;
-    const completion_mask_t& get_completion_mask() const { return _completion_mask; }
-    enum compass_cal_status_t get_status() const { return _status; }
-    float get_fitness() const { return sqrtf(_fitness); }
     float get_orientation_confidence() const { return _orientation_confidence; }
+
+    // get completion percentage (0 to 100) for reporting to GCS
+    float get_completion_percent() const;
+
+    // get how many attempts have been made to calibrate for reporting to GCS
     uint8_t get_attempt() const { return _attempt; }
 
+    // get completion mask for mavlink reporting (a bitmask of faces/directions for which we have compass samples)
+    typedef uint8_t completion_mask_t[10];
+    const completion_mask_t& get_completion_mask() const { return _completion_mask; }
+
 private:
+
+    // results
     class param_t {
     public:
         float* get_sphere_params() {
@@ -67,10 +76,10 @@ private:
             return &offset.x;
         }
 
-        float radius;
-        Vector3f offset;
-        Vector3f diag;
-        Vector3f offdiag;
+        float radius;       // magnetic field strength calculated from samples
+        Vector3f offset;    // offsets
+        Vector3f diag;      // diagonal scaling
+        Vector3f offdiag;   // off diagonal scaling
     };
 
     // compact class for approximate attitude, to save memory
@@ -84,6 +93,7 @@ private:
         int8_t yaw;
     };
 
+    // compact class to hold compass samples, to save memory
     class CompassSample {
     public:
         Vector3f get() const;
@@ -95,40 +105,7 @@ private:
         int16_t z;
     };
 
-    enum Rotation _orientation;
-    enum Rotation _orig_orientation;
-    bool _is_external;
-    bool _check_orientation;
-    bool _fix_orientation;
-    uint8_t _compass_idx;
-
-    enum compass_cal_status_t _status;
-
-    // timeout watchdog state
-    uint32_t _last_sample_ms;
-
-    // behavioral state
-    float _delay_start_sec;
-    uint32_t _start_time_ms;
-    bool _retry;
-    float _tolerance;
-    uint8_t _attempt;
-    uint16_t _offset_max;
-
-    completion_mask_t _completion_mask;
-
-    //fit state
-    class param_t _params;
-    uint16_t _fit_step;
-    CompassSample *_sample_buffer;
-    float _fitness; // mean squared residuals
-    float _initial_fitness;
-    float _sphere_lambda;
-    float _ellipsoid_lambda;
-    uint16_t _samples_collected;
-    uint16_t _samples_thinned;
-    float _orientation_confidence;
-
+    // set status including any required initialisation
     bool set_status(compass_cal_status_t status);
 
     // returns true if sample should be added to buffer
@@ -138,37 +115,78 @@ private:
     // returns true if fit is acceptable
     bool fit_acceptable();
 
+    // clear sample buffer and reset offsets and scaling to their defaults
     void reset_state();
+
+    // initialize fitness before starting a fit
     void initialize_fit();
 
+    // true if enough samples have been collected and fitting has begun (aka runniong())
     bool fitting() const;
 
     // thins out samples between step one and step two
     void thin_samples();
 
+    // calc the fitness of a single sample vs a set of parameters (offsets, diagonals, off diagonals)
     float calc_residual(const Vector3f& sample, const param_t& params) const;
+
+    // calc the fitness of the parameters (offsets, diagonals, off diagonals) vs all the samples collected
+    // returns 1.0e30f if the sample buffer is empty
     float calc_mean_squared_residuals(const param_t& params) const;
     float calc_mean_squared_residuals() const;
 
+    // calculate initial offsets by simply taking the average values of the samples
     void calc_initial_offset();
+
+    // run sphere fit to calculate diagonals and offdiagonals
     void calc_sphere_jacob(const Vector3f& sample, const param_t& params, float* ret) const;
     void run_sphere_fit();
 
+    // run ellipsoid fit to calculate diagonals and offdiagonals
     void calc_ellipsoid_jacob(const Vector3f& sample, const param_t& params, float* ret) const;
     void run_ellipsoid_fit();
 
-    /**
-     * Update #_completion_mask for the geodesic section of \p v. Corrections
-     * are applied to \p v with #_params.
-     *
-     * @param v[in] A vector representing one calibration sample.
-     */
-    void update_completion_mask(const Vector3f& v);
-    /**
-     * Reset and update #_completion_mask with the current samples.
-     */
+    // update the completion mask based on a single sample
+    void update_completion_mask(const Vector3f& sample);
+
+    // reset and updated the completion mask using all samples in the sample buffer
     void update_completion_mask();
 
+    // calculate compass orientation
     Vector3f calculate_earth_field(CompassSample &sample, enum Rotation r);
     bool calculate_orientation();
+
+    uint8_t _compass_idx;                   // index of the compass providing data
+    enum compass_cal_status_t _status;      // current state of calibrator
+    uint32_t _last_sample_ms;               // system time of last sample received for timeout
+
+    // values provided by caller
+    float _delay_start_sec;                 // seconds to delay start of calibration (provided by caller)
+    bool _retry;                            // true if calibration should be restarted on failured (provided by caller)
+    float _tolerance;                       // worst acceptable tolerance (aka fitness).  see set_tolerance()
+    uint16_t _offset_max;                   // maximum acceptable offsets (provided by caller)
+
+    // behavioral state
+    uint32_t _start_time_ms;                // system time start() function was last called
+    uint8_t _attempt;                       // number of attempts have been made to calibrate
+    completion_mask_t _completion_mask;     // bitmask of directions in which we have samples
+    CompassSample *_sample_buffer;          // buffer of sensor values
+    uint16_t _samples_collected;            // number of samples in buffer
+    uint16_t _samples_thinned;              // number of samples removed by the thin_samples() call (called before step 2 begins)
+
+    // fit state
+    class param_t _params;                  // latest calibration outputs
+    uint16_t _fit_step;                     // step during RUNNING_STEP_ONE/TWO which performs sphere fit and ellipsoid fit
+    float _fitness;                         // fitness (mean squared residuals) of current parameters
+    float _initial_fitness;                 // fitness before latest "fit" was attempted (used to determine if fit was an improvement)
+    float _sphere_lambda;                   // sphere fit's lambda
+    float _ellipsoid_lambda;                // ellipsoid fit's lambda
+
+    // variables for orientation checking
+    enum Rotation _orientation;             // latest detected orientation
+    enum Rotation _orig_orientation;        // original orientation provided by caller
+    bool _is_external;                      // true if compass is external (provided by caller)
+    bool _check_orientation;                // true if orientation should be automatically checked
+    bool _fix_orientation;                  // true if orientation should be fixed if necessary
+    float _orientation_confidence;          // measure of confidence in automatic orientation detection
 };

--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -16,7 +16,6 @@ CompassLearn::CompassLearn(AP_AHRS &_ahrs, Compass &_compass) :
     ahrs(_ahrs),
     compass(_compass)
 {
-    gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: Initialised");
     for (uint8_t i=0; i<compass.get_count(); i++) {
         if (compass._state[i].use_for_yaw) {
             // reset scale factors, we can't learn scale factors in
@@ -134,7 +133,6 @@ void CompassLearn::update(void)
             best_error = 0;
             best_yaw_deg = 0;
             best_offsets.zero();
-            gcs().send_text(MAV_SEVERITY_INFO, "CompassLearn: finished");
             AP_Notify::flags.compass_cal_running = false;
             AP_Notify::events.compass_cal_saved = true;
         }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -554,13 +554,16 @@ void NavEKF2_core::readGpsData()
             }
 
             if (gpsGoodToAlign && !have_table_earth_field) {
-                table_earth_field_ga = AP_Declination::get_earth_field_ga(gpsloc);
-                table_declination = radians(AP_Declination::get_declination(gpsloc.lat*1.0e-7,
-                                                                            gpsloc.lng*1.0e-7));
-                have_table_earth_field = true;
-                if (frontend->_mag_ef_limit > 0) {
-                    // initialise earth field from tables
-                    stateStruct.earth_magfield = table_earth_field_ga;
+                const Compass *compass = _ahrs->get_compass();
+                if (compass && compass->have_scale_factor(magSelectIndex)) {
+                    table_earth_field_ga = AP_Declination::get_earth_field_ga(gpsloc);
+                    table_declination = radians(AP_Declination::get_declination(gpsloc.lat*1.0e-7,
+                                                                                gpsloc.lng*1.0e-7));
+                    have_table_earth_field = true;
+                    if (frontend->_mag_ef_limit > 0) {
+                        // initialise earth field from tables
+                        stateStruct.earth_magfield = table_earth_field_ga;
+                    }
                 }
             }
             

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -363,6 +363,8 @@ protected:
     MAV_RESULT handle_command_do_set_mode(const mavlink_command_long_t &packet);
     MAV_RESULT handle_command_get_home_position(const mavlink_command_long_t &packet);
 
+    MAV_RESULT handle_fixed_mag_cal_yaw(const mavlink_command_long_t &packet);
+
     // vehicle-overridable message send function
     virtual bool try_send_message(enum ap_message id);
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -2237,6 +2237,18 @@ void GCS_MAVLINK::handle_command_ack(const mavlink_message_t* msg)
 }
 
 /*
+  handle MAV_CMD_FIXED_MAG_CAL_YAW
+ */
+MAV_RESULT GCS_MAVLINK::handle_fixed_mag_cal_yaw(const mavlink_command_long_t &packet)
+{
+    Compass &compass = AP::compass();
+    return compass.mag_cal_fixed_yaw(packet.param1,
+                                     uint8_t(packet.param2),
+                                     packet.param3,
+                                     packet.param4);
+}
+
+/*
   handle messages which don't require vehicle specific data
  */
 void GCS_MAVLINK::handle_common_message(mavlink_message_t *msg)
@@ -2773,6 +2785,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_message(mavlink_command_long_t &pack
         result = handle_flight_termination(packet);
         break;
 
+    case MAV_CMD_FIXED_MAG_CAL_YAW:
+        result = handle_fixed_mag_cal_yaw(packet);
+        break;
+        
     default:
         result = MAV_RESULT_UNSUPPORTED;
         break;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -158,6 +158,8 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
 
     AP_GROUPINFO("GPS_DRIFT_S", 35, SITL,  gps_drift_spd, 0),
 
+    AP_GROUPINFO("MAG_SCALING",    60, SITL,  mag_scaling, 1),
+
     AP_GROUPEND
 };
     

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -176,6 +176,7 @@ public:
     AP_Int8  odom_enable; // enable visual odomotry data
     AP_Int8  telem_baudlimit_enable; // enable baudrate limiting on links
     AP_Float flow_noise; // optical flow measurement noise (rad/sec)
+    AP_Float mag_scaling; // scaling factor on first compasses
 
     // wind control
     enum WindType {


### PR DESCRIPTION
This is a fast compass calibration given vehicle position and yaw. The calibrations results in zero diagonal and off-diagonal elements, so is only suitable for vehicles where the field is close to spherical. It is useful for large vehicles where moving the vehicle to calibrate it is difficult.

The offsets of the selected compasses are set to values to bring them into consistency with the WMM tables at the given latitude and longitude. If compass_mask is zero then all enabled compasses are calibrated.

This assumes that the compass is correctly scaled in milliGauss

MAVProxy implements this using the "magcal yaw" command.

This PR depends on this change to mavlink:
https://github.com/matternet/mavlink/pull/3


UPDATE
This PR now also includes the new COMPASS_SCALE estimation, allowing us to compensate for incorrectly scaled compasses. On a full 3D compass cal the COMPASS_SCALE will be automatically estimated. If COMPASS_SCALE is not set (ie. it is zero) then the use of the WMM constraints in the EKF are disabled