### PR TITLE
AP_Mission: added MIS_FLIGHT_ID

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -29,6 +29,12 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),
 
+    // @Param: FLIGHT_ID
+    // @DisplayName: Mission flight ID
+    // @Description: Mission ID for log analysis
+    // @User: Advanced
+    AP_GROUPINFO("FLIGHT_ID",  20, AP_Mission, _flight_id, 0),
+    
     AP_GROUPEND
 };
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -530,6 +530,7 @@ private:
     AP_Int16                _cmd_total;  // total number of commands in the mission
     AP_Int8                 _restart;   // controls mission starting point when entering Auto mode (either restart from beginning of mission or resume from last command run)
     AP_Int16                _options;    // bitmask options for missions, currently for mission clearing on reboot but can be expanded as required
+    AP_Int32                _flight_id; // user settable ID for log analysis
 
     // pointer to main program functions
     mission_cmd_fn_t        _cmd_start_fn;  // pointer to function which will be called when a new command is started


### PR DESCRIPTION
user settable ID of flight for log analysis. This came from a discussion with Alice
