### PR TITLE
Added support for UAVCAN rangefinders

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.cpp
@@ -1,0 +1,105 @@
+#include <AP_HAL/AP_HAL.h>
+
+#if HAL_WITH_UAVCAN
+
+#include "AP_RangeFinder_UAVCAN.h"
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_BoardConfig/AP_BoardConfig_CAN.h>
+
+#if HAL_OS_POSIX_IO
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+extern const AP_HAL::HAL& hal;
+
+#define debug_rangefinder_uavcan(level, fmt, args...) do { if ((level) <= AP_BoardConfig_CAN::get_can_debug()) { printf(fmt, ##args); }} while (0)
+
+/*
+  constructor - registers instance at top Rangefinder driver
+ */
+AP_RangeFinder_UAVCAN::AP_RangeFinder_UAVCAN(RangeFinder::RangeFinder_State &_state)
+    : AP_RangeFinder_Backend(_state)
+{
+    _sem = hal.util->new_semaphore();
+
+    for (uint8_t i = 0; i < MAX_NUMBER_OF_CAN_DRIVERS; i++) {
+        AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(i);
+        if (ap_uavcan == nullptr) {
+            continue;
+        }
+        
+        uint8_t free = ap_uavcan->find_smallest_free_rangefinder_node();
+        if (free == UINT8_MAX) {
+            continue;
+        }
+        if (register_uavcan_rangefinder(i, free)) {
+            break;
+        }
+    }
+}
+
+AP_RangeFinder_UAVCAN::~AP_RangeFinder_UAVCAN()
+{
+    if (!_initialized) {
+        return;
+    }
+    
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(_manager);
+    if (ap_uavcan == nullptr) {
+        return;
+    }
+    
+    ap_uavcan->remove_rangefinder_listener(this);
+    delete _sem;
+    _sem = nullptr;
+    
+    debug_rangefinder_uavcan(2, "AP_RangeFinder_UAVCAN destructed\n\r");
+}
+
+// Read the sensor
+void AP_RangeFinder_UAVCAN::update(void)
+{
+    _sem->take_blocking();
+    uint32_t now = AP_HAL::millis();
+    if (now - _last_update_ms > 200) {
+        set_status(RangeFinder::RangeFinder_NoData);
+    } else {
+        state.distance_cm = _distance * 100;
+        set_status(_status);
+    }
+    _sem->give();
+}
+
+void AP_RangeFinder_UAVCAN::handle_rangefinder_msg(float distance, RangeFinder::RangeFinder_Status status)
+{
+    _sem->take_blocking();
+    _distance = distance;
+    _status = status;
+    _last_update_ms = AP_HAL::millis();
+    _sem->give();
+}
+
+bool AP_RangeFinder_UAVCAN::register_uavcan_rangefinder(uint8_t mgr, uint8_t node)
+{
+    AP_UAVCAN *ap_uavcan = AP_UAVCAN::get_uavcan(mgr);
+    if (ap_uavcan == nullptr) {
+        return false;
+    }
+    _manager = mgr;
+
+    if (ap_uavcan->register_rangefinder_listener_to_node(this, node)) {
+        debug_rangefinder_uavcan(2, "AP_RangeFinder_UAVCAN loaded\n\r");
+
+        _initialized = true;
+
+        return true;
+    }
+
+    return false;
+}
+
+#endif // HAL_WITH_UAVCAN
+

--- a/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "RangeFinder_Backend.h"
+#include <AP_UAVCAN/AP_UAVCAN.h>
+
+class AP_RangeFinder_UAVCAN : public AP_RangeFinder_Backend {
+public:
+    AP_RangeFinder_UAVCAN(RangeFinder::RangeFinder_State &_state);
+    ~AP_RangeFinder_UAVCAN() override;
+
+    void update() override;
+
+    // This method is called from UAVCAN thread
+    void handle_rangefinder_msg(float distance, RangeFinder::RangeFinder_Status status) override;
+
+    bool register_uavcan_rangefinder(uint8_t mgr, uint8_t node);
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_UNKNOWN;
+    }
+
+private:
+    uint8_t _instance;
+    float _distance;
+    uint32_t _last_update_ms;
+    RangeFinder::RangeFinder_Status _status;
+    uint8_t _manager;
+    AP_HAL::Semaphore *_sem;
+
+    bool _initialized;
+};

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -35,7 +35,9 @@
 #include "AP_RangeFinder_NMEA.h"
 #include "AP_RangeFinder_Wasp.h"
 #include "AP_RangeFinder_Benewake.h"
+#if HAL_WITH_UAVCAN
 #include "AP_RangeFinder_UAVCAN.h"
+#endif
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL &hal;

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -35,6 +35,7 @@
 #include "AP_RangeFinder_NMEA.h"
 #include "AP_RangeFinder_Wasp.h"
 #include "AP_RangeFinder_Benewake.h"
+#include "AP_RangeFinder_UAVCAN.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
 
 extern const AP_HAL::HAL &hal;
@@ -764,6 +765,11 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
             drivers[instance] = new AP_RangeFinder_Benewake(state[instance], serial_manager, serial_instance++, AP_RangeFinder_Benewake::BENEWAKE_TFmini);
         }
         break;
+#if HAL_WITH_UAVCAN
+    case RangeFinder_TYPE_UAVCAN:
+        drivers[instance] = new AP_RangeFinder_UAVCAN(state[instance]);
+        break;
+#endif
     default:
         break;
     }

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -63,6 +63,7 @@ public:
         RangeFinder_TYPE_BenewakeTF02 = 19,
         RangeFinder_TYPE_BenewakeTFmini = 20,
         RangeFinder_TYPE_PLI2CV3HP = 21,
+        RangeFinder_TYPE_UAVCAN = 24,
     };
 
     enum RangeFinder_Function {

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -33,6 +33,9 @@ public:
 
     virtual void handle_msg(mavlink_message_t *msg) { return; }
 
+    // callback for UAVCAN messages
+    virtual void handle_rangefinder_msg(float distance, RangeFinder::RangeFinder_Status status) {}
+    
     void update_pre_arm_check();
 
     enum Rotation orientation() const { return (Rotation)state.orientation.get(); }

--- a/libraries/AP_UAVCAN/AP_UAVCAN.h
+++ b/libraries/AP_UAVCAN/AP_UAVCAN.h
@@ -14,6 +14,7 @@
 
 #include <AP_GPS/GPS_Backend.h>
 #include <AP_Baro/AP_Baro_Backend.h>
+#include <AP_RangeFinder/RangeFinder_Backend.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_BattMonitor/AP_BattMonitor_Backend.h>
 
@@ -36,6 +37,7 @@
 #define AP_UAVCAN_MAX_GPS_NODES 4
 #define AP_UAVCAN_MAX_MAG_NODES 4
 #define AP_UAVCAN_MAX_BARO_NODES 4
+#define AP_UAVCAN_MAX_RANGEFINDER_NODES 4
 #define AP_UAVCAN_MAX_BI_NUMBER 4
 
 #define AP_UAVCAN_SW_VERS_MAJOR 1
@@ -142,6 +144,18 @@ public:
     uint8_t find_smallest_free_bi_id();
     void update_bi_state(uint8_t id);
 
+    struct Rangefinder_Info {
+        float distance;
+        uint8_t status;
+    };
+
+    uint8_t register_rangefinder_listener(AP_RangeFinder_Backend* new_listener, uint8_t preferred_channel);
+    uint8_t register_rangefinder_listener_to_node(AP_RangeFinder_Backend* new_listener, uint8_t node);
+    void remove_rangefinder_listener(AP_RangeFinder_Backend* rem_listener);
+    Rangefinder_Info *find_rangefinder_node(uint8_t node);
+    uint8_t find_smallest_free_rangefinder_node();
+    void update_rangefinder_state(uint8_t node);
+    
     // synchronization for RC output
     void SRV_sem_take();
     void SRV_sem_give();
@@ -221,6 +235,13 @@ private:
     uint16_t _bi_BM_listener_to_id[AP_UAVCAN_MAX_LISTENERS];
     AP_BattMonitor_Backend* _bi_BM_listeners[AP_UAVCAN_MAX_LISTENERS];
 
+    // ------------------------- RANGEFINDER
+    uint8_t _rangefinder_nodes[AP_UAVCAN_MAX_RANGEFINDER_NODES];
+    uint8_t _rangefinder_node_taken[AP_UAVCAN_MAX_RANGEFINDER_NODES];
+    Rangefinder_Info _rangefinder_node_state[AP_UAVCAN_MAX_RANGEFINDER_NODES];
+    uint8_t _rangefinder_listener_to_node[AP_UAVCAN_MAX_LISTENERS];
+    AP_RangeFinder_Backend* _rangefinder_listeners[AP_UAVCAN_MAX_LISTENERS];
+    
     struct {
         uint16_t pulse;
         uint16_t safety_pulse;


### PR DESCRIPTION
This adds support for UAVCAN rangefinders for copter 3.6.7 rebase branch
Has only had minimal testing
This has RNGFND_TYPE=24 in the cube. Make sure you set the AP_Periph CAN params too