### PR TITLE
Fixed I2C interrupt handling in ChibiOS

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/mcuconf.h
@@ -384,3 +384,5 @@
  */
 #define STM32_WDG_USE_IWDG                  FALSE
 
+// limit to 6 interrupts per byte on I2C
+#define STM32_I2C_ISR_LIMIT 6


### PR DESCRIPTION
This fixes a recently discovered issue with I2C interrupt handling in ChibiOS on STM32F4xx MCUs. The fix includes both handling the required interrupt combinations and adding an interrupt quota per byte to prevent any future similar issues from causing a lockup
