### PR TITLE
Added MIS_OPTIONS bit for continue after land

### DIFF
--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -21,7 +21,7 @@ pushd $HOME
 # PX4 toolchain
 dir=$ARM_ROOT
 if [ ! -d "$HOME/opt/$dir" ]; then
-  wget http://firmware.ardupilot.org/Tools/PX4-tools/$ARM_TARBALL
+  wget http://firmware.ardupilot.org/Tools/STM32-tools/archived/$ARM_TARBALL
   tar -xf $ARM_TARBALL -C opt
 fi
 

--- a/Tools/scripts/install-prereqs-arch.sh
+++ b/Tools/scripts/install-prereqs-arch.sh
@@ -19,7 +19,7 @@ ARCH_AUR_PKGS="genromfs"
 # (see https://launchpad.net/gcc-arm-embedded/)
 ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
 ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
-ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/PX4-tools/$ARM_TARBALL"
+ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/archived/$ARM_TARBALL"
 
 # Ardupilot Tools
 ARDUPILOT_TOOLS="ardupilot/Tools/autotest"

--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -26,7 +26,7 @@ fi
 # (see https://launchpad.net/gcc-arm-embedded/)
 ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
 ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
-ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/PX4-tools/$ARM_TARBALL"
+ARM_TARBALL_URL="http://firmware.ardupilot.org/Tools/STM32-tools/archived/$ARM_TARBALL"
 
 # Ardupilot Tools
 ARDUPILOT_TOOLS="Tools/autotest"

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -25,7 +25,7 @@ const AP_Param::GroupInfo AP_Mission::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Mission options bitmask
     // @Description: Bitmask of what options to use in missions.
-    // @Bitmask: 0:Clear Mission on reboot
+    // @Bitmask: 0:Clear Mission on reboot, 2:ContinueAfterLand
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  2, AP_Mission, _options, AP_MISSION_OPTIONS_DEFAULT),
 

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -39,6 +39,7 @@
 
 #define AP_MISSION_OPTIONS_DEFAULT          0       // Do not clear the mission when rebooting
 #define AP_MISSION_MASK_MISSION_CLEAR       (1<<0)  // If set then Clear the mission on boot
+#define AP_MISSION_MASK_CONTINUE_AFTER_LAND (1<<2)  // Allow mission to continue after land
 
 /// @class    AP_Mission
 /// @brief    Object managing Mission
@@ -459,6 +460,15 @@ public:
     // switch to that mission item.  Returns false if no DO_LAND_START
     // available.
     bool jump_to_landing_sequence(void);
+
+    /*
+      return true if MIS_OPTIONS is set to allow continue of mission
+      logic after a land. If this is false then after a landing is
+      complete the vehicle should disarm and mission logic should stop
+     */
+    bool continue_after_land(void) const {
+        return (_options.get() & AP_MISSION_MASK_CONTINUE_AFTER_LAND) != 0;
+    }
 
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
This changes the default behaviour of mission process on the completion of a NAV_LAND. The current behaviour is to continue with the next mission item. That creates a problem for missions where there are multiple contingencies planned in one mission where each has it's own NAV_LAND.
With this PR the behaviour is changed so that on completion of a NAV_LAND the copter will disarm and stop mission processing. If MIS_OPTIONS=4 is set then the old behaviour is restored and the mission continues on landing completion.
This also changes the messages when landing. The code previously printed "Landed" continuously while descending. It now prints "Landed" only once when land is complete and prints "Landing" once when landing descent is started.