### PR TITLE
AP_RangeFinder: allow for power on of CAN rangefinder after boot

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_UAVCAN.h
@@ -26,6 +26,9 @@ private:
     RangeFinder::RangeFinder_Status _status;
     uint8_t _manager;
     AP_HAL::Semaphore *_sem;
+    uint32_t _last_init_check_ms;
+
+    void init_rangefinder();
 
     bool _initialized;
 };


### PR DESCRIPTION
this allows a UAVCAN rangefinder to register after boot, allowing it
to be powered off while idle