### PR TITLE
Copter: auto-reset baro cal when disarmed (for 4.0 branch)

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -454,6 +454,10 @@ void Copter::one_hz_loop()
         // set all throttle channel settings
         motors->set_throttle_range(channel_throttle->get_radio_min(), channel_throttle->get_radio_max());
 #endif
+
+        // reset baro cal when on the ground
+        barometer.update_calibration();
+        ahrs.resetHeightDatum();
     }
 
     // update assigned functions and enable auxiliary servos

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -279,11 +279,11 @@ void AP_Baro::calibrate(bool save)
 void AP_Baro::update_calibration()
 {
     const uint32_t now = AP_HAL::millis();
-    const bool do_notify = now - _last_notify_ms > 10000;
-    if (do_notify) {
-        _last_notify_ms = now;
-    }
     for (uint8_t i=0; i<_num_sensors; i++) {
+        const bool do_notify = now - _last_notify_ms[i] > 10000;
+        if (do_notify) {
+            _last_notify_ms[i] = now;
+        }
         if (healthy(i)) {
             float corrected_pressure = get_pressure(i) + sensors[i].p_correction;
             sensors[i].ground_pressure.set(corrected_pressure);

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -247,7 +247,7 @@ private:
     float                               _guessed_ground_temperature; // currently ground temperature estimate using our best abailable source
 
     // when did we last notify the GCS of new pressure reference?
-    uint32_t                            _last_notify_ms;
+    uint32_t                            _last_notify_ms[BARO_MAX_INSTANCES];
 
     bool _add_backend(AP_Baro_Backend *backend);
     void _probe_i2c_barometers(void);


### PR DESCRIPTION
resets at 1Hz, as discussed with Alice