### PR TITLE
SITL: tweaks to bring simulated vehicle closer to matternet vehicle

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -559,10 +559,7 @@ void AP_Baro::init(void)
     if (sitl == nullptr) {
         AP_HAL::panic("No SITL pointer");
     }
-    if (sitl->baro_count > 1) {
-        ::fprintf(stderr, "More than one baro not supported.  Sorry.");
-    }
-    if (sitl->baro_count == 1) {
+    for (uint8_t i=0; i<sitl->baro_count; i++) {
         ADD_BACKEND(new AP_Baro_SITL(*this));
     }
 #elif HAL_BARO_DEFAULT == HAL_BARO_HIL

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -117,11 +117,11 @@ void Motor::current_and_voltage(const struct sitl_input &input, float &voltage, 
     // get motor speed from 0 to 1
     float motor_speed = constrain_float((input.servos[motor_offset+servo]-1100)/900.0, 0, 1);
 
-    // assume 10A per motor at full speed
-    current = 10 * motor_speed;
+    // assume 19A per motor at full speed
+    current = 19 * motor_speed;
 
-    // assume 3S, and full throttle drops voltage by 0.7V
+    // assume 12S, and full throttle drops voltage by 12.0V
     if (AP::sitl()) {
-        voltage = AP::sitl()->batt_voltage - motor_speed * 0.7;
+        voltage = AP::sitl()->batt_voltage - motor_speed * 12.0;
     }
 }

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -39,7 +39,7 @@ MultiCopter::MultiCopter(const char *frame_str) :
     if (strstr(frame_str, "-fast")) {
         frame->init(gross_mass(), 0.5, 85, 4*radians(360));
     } else {
-        frame->init(gross_mass(), 0.51, 15, 4*radians(360));
+        frame->init(gross_mass(), 0.32, 50, 4*radians(360));
     }
     frame_height = 0.1;
     ground_behavior = GROUND_BEHAVIOR_NO_MOVEMENT;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo SITL::var_info[] = {
     AP_GROUPINFO("SERVO_SPEED",   16, SITL,  servo_speed,  0.14),
     AP_GROUPINFO("GPS_GLITCH",    17, SITL,  gps_glitch,  0),
     AP_GROUPINFO("GPS_HZ",        18, SITL,  gps_hertz,  5),
-    AP_GROUPINFO("BATT_VOLTAGE",  19, SITL,  batt_voltage,  12.6f),
+    AP_GROUPINFO("BATT_VOLTAGE",  19, SITL,  batt_voltage,  48.0f),
     AP_GROUPINFO("ARSPD_RND",     20, SITL,  arspd_noise,  0.5f),
     AP_GROUPINFO("ACCEL_FAIL",    21, SITL,  accel_fail,  0),
     AP_GROUPINFO("BARO_DRIFT",    22, SITL,  baro_drift,  0),

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -167,7 +167,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("TWIST_TIME",  40, SITL,  twist.t, 0),
 
     AP_GROUPINFO("GND_BEHAV",   41, SITL,  gnd_behav, -1),
-    AP_GROUPINFO("BARO_COUNT",  42, SITL,  baro_count,  1),
+    AP_GROUPINFO("BARO_COUNT",  42, SITL,  baro_count,  2),
 
     AP_GROUPINFO("GPS_HDG",     43, SITL,  gps_hdg_enabled, 0),
 


### PR DESCRIPTION
This brings the current draw, voltage and hover throttle approximately in line with the real vehicle
