### PR TITLE
AP_NavEKF2: allow for Z compass error changing per flight (4.0 version)

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -148,6 +148,7 @@ void NavEKF2_core::controlMagYawReset()
                 // send in-flight yaw alignment status to console
                 if (finalResetRequest) {
                     gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u in-flight yaw alignment complete",(unsigned)imu_index);
+                    pending_z_mag_correction = true;
                 } else if (interimResetRequest) {
                     gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u ground mag anomaly, yaw re-aligned",(unsigned)imu_index);
                 }
@@ -387,6 +388,17 @@ void NavEKF2_core::FuseMagnetometer()
         MagPred[0] = DCM[0][0]*magN + DCM[0][1]*magE  + DCM[0][2]*magD + magXbias;
         MagPred[1] = DCM[1][0]*magN + DCM[1][1]*magE  + DCM[1][2]*magD + magYbias;
         MagPred[2] = DCM[2][0]*magN + DCM[2][1]*magE  + DCM[2][2]*magD + magZbias;
+
+        if (pending_z_mag_correction && frontend->_mag_learn_limit > 0) {
+            pending_z_mag_correction = false;
+            float correction = magDataDelayed.mag[2] - MagPred[2];
+            const float correction_limit_ga = frontend->_mag_learn_limit*0.001*3;
+            correction = constrain_float(correction,
+                                         -correction_limit_ga, correction_limit_ga);
+            stateStruct.body_magfield[2] += correction;
+            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u magZ correction %.0f",(unsigned)imu_index, correction*1000);
+            MagPred[2] += correction;
+        }
 
         // calculate the measurement innovation for each axis
         for (uint8_t i = 0; i<=2; i++) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -1526,9 +1526,11 @@ void NavEKF2_core::MagOffsetConstrain(void)
 {
     if (frontend->_mag_learn_limit > 0) {
         float limit_ga = frontend->_mag_learn_limit * 0.001f;
+        // allow higher limit on Z due to more variability observed in vehicles
+        float limit_ga_z = limit_ga * 3;
         stateStruct.body_magfield.x = constrain_float(stateStruct.body_magfield.x, -limit_ga, limit_ga);
         stateStruct.body_magfield.y = constrain_float(stateStruct.body_magfield.y, -limit_ga, limit_ga);
-        stateStruct.body_magfield.z = constrain_float(stateStruct.body_magfield.z, -limit_ga, limit_ga);
+        stateStruct.body_magfield.z = constrain_float(stateStruct.body_magfield.z, -limit_ga_z, limit_ga_z);
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -1184,6 +1184,9 @@ private:
     // string representing last reason for prearm failure
     char prearm_fail_string[41];
 
+    // true when we should align learned offsets with next z reading
+    bool pending_z_mag_correction;
+
     // performance counters
     AP_HAL::Util::perf_counter_t  _perf_UpdateFilter;
     AP_HAL::Util::perf_counter_t  _perf_CovariancePrediction;


### PR DESCRIPTION
this allows for 3x the learned compass offsets in Z axis, and
automatically adjusts the initial learned EKF magZ correction at the
time that final yaw alignment is done on takeoff.

This works around an issue with changes in the Z magnetic field of the
vehicle between flights
This is the 4.0 version of PR #120 