### PR TITLE
DataFlash: use LOG_FILE_DSMROT even in log persistance window

### DIFF
--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -811,7 +811,8 @@ void DataFlash_File::stop_logging(void)
 
 void DataFlash_File::PrepForArming()
 {
-    if (logging_started()) {
+    if (logging_started() &&
+        _front._params.file_disarm_rot == 0) {
         return;
     }
     start_new_log();


### PR DESCRIPTION
if we re-arm within 60s persist window then start new log if
LOG_FILE_DSMROT=1