### PR TITLE
Send NAMED_VALUE_INT GPSPRIMARY at 1Hz

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -814,6 +814,13 @@ void AP_GPS::update(void)
     AP_Notify::flags.gps_status = state[primary_instance].status;
     AP_Notify::flags.gps_num_sats = state[primary_instance].num_sats;
 
+    uint32_t now = AP_HAL::millis();
+    if (now - last_gps_primary_ms > 1000) {
+        // tell the GCS which GPS is primary
+        last_gps_primary_ms = now;
+        gcs().send_named_int("GPSPRIMARY", primary_instance);
+    }
+
 }
 
 void AP_GPS::handle_gps_inject(const mavlink_message_t *msg)

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -552,6 +552,9 @@ private:
     bool _output_is_blended; // true when a blended GPS solution being output
     uint8_t _blend_health_counter;  // 0 = perfectly health, 100 = very unhealthy
 
+    // time of last GPS primary report
+    uint32_t last_gps_primary_ms;
+
     /*
       track change in position and height since arming. Used for
       pre-takeoff check

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -38,6 +38,11 @@ void GCS::send_named_float(const char *name, float value) const
     FOR_EACH_ACTIVE_CHANNEL(send_named_float(name, value));
 }
 
+void GCS::send_named_int(const char *name, int32_t value) const
+{
+    FOR_EACH_ACTIVE_CHANNEL(send_named_int(name, value));
+}
+
 void GCS::send_home() const
 {
     FOR_EACH_ACTIVE_CHANNEL(send_home());

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -192,6 +192,7 @@ public:
     void send_vfr_hud();
     void send_vibration() const;
     void send_named_float(const char *name, float value) const;
+    void send_named_int(const char *name, int32_t value) const;
     void send_home() const;
     void send_ekf_origin() const;
     virtual void send_position_target_global_int() { };
@@ -601,6 +602,7 @@ public:
     void send_message(enum ap_message id);
     void send_mission_item_reached_message(uint16_t mission_index);
     void send_named_float(const char *name, float value) const;
+    void send_named_int(const char *name, int32_t value) const;
     void send_home() const;
     void send_ekf_origin() const;
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1604,6 +1604,13 @@ void GCS_MAVLINK::send_named_float(const char *name, float value) const
     mavlink_msg_named_value_float_send(chan, AP_HAL::millis(), float_name, value);
 }
 
+void GCS_MAVLINK::send_named_int(const char *name, int32_t value) const
+{
+    char int_name[MAVLINK_MSG_NAMED_VALUE_INT_FIELD_NAME_LEN+1] {};
+    strncpy(int_name, name, MAVLINK_MSG_NAMED_VALUE_INT_FIELD_NAME_LEN);
+    mavlink_msg_named_value_int_send(chan, AP_HAL::millis(), int_name, value);
+}
+
 void GCS_MAVLINK::send_home() const
 {
     if (!HAVE_PAYLOAD_SPACE(chan, HOME_POSITION)) {


### PR DESCRIPTION
This sends the mavlink msg NAMED_VALUE_INT with name "GPSPRIMARY" at 1Hz to indicate which GPS is being used
Values are:
 - 0: first GPS is primary
 - 1: 2nd GPS is primary
 - 2: blended GPS is primary
