### PR TITLE
Fixed EKF handling of compass failure and battery change

### DIFF
--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -22,7 +22,13 @@ AP_Compass_SITL::AP_Compass_SITL(Compass &compass):
             // save so the compass always comes up configured in SITL
             save_dev_id(_compass_instance[i]);
         }
-        
+
+        // we want to simulate a calibrated compass by default, so set
+        // scale to 1
+        AP_Param::set_default_by_name("COMPASS_SCALE", 1);
+        AP_Param::set_default_by_name("COMPASS_SCALE2", 1);
+        AP_Param::set_default_by_name("COMPASS_SCALE3", 1);
+
         // make first compass external
         set_external(_compass_instance[0], true);
 

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -14,7 +14,9 @@ AP_Compass_SITL::AP_Compass_SITL(Compass &compass):
         _compass._setup_earth_field();
         for (uint8_t i=0; i<SITL_NUM_COMPASSES; i++) {
             // default offsets to correct value
-            compass.set_offsets(i, _sitl->mag_ofs);
+            if (_compass.get_offsets(i).is_zero()) {
+                compass.set_offsets(i, _sitl->mag_ofs);
+            }
             
             _compass_instance[i] = register_compass();
             set_dev_id(_compass_instance[i], AP_HAL::Device::make_bus_id(AP_HAL::Device::BUS_TYPE_SITL, i, 0, DEVTYPE_SITL));

--- a/libraries/AP_Compass/AP_Compass_SITL.h
+++ b/libraries/AP_Compass/AP_Compass_SITL.h
@@ -36,7 +36,7 @@ private:
     uint32_t _last_sample_time;
 
     Vector3f _mag_accum[SITL_NUM_COMPASSES];
-    uint32_t _accum_count;
+    uint32_t _accum_count[SITL_NUM_COMPASSES];
 
     void _setup_eliptical_correcion();
     

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -108,6 +108,7 @@ void NavEKF2_core::setWindMagStateLearningMode()
     bool setMagInhibit = !magCalRequested || magCalDenied;
     if (!inhibitMagStates && setMagInhibit) {
         inhibitMagStates = true;
+        resetMagBodyVariances();
     } else if (inhibitMagStates && !setMagInhibit) {
         inhibitMagStates = false;
         if (magFieldLearned) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -120,7 +120,7 @@ void NavEKF2_core::setWindMagStateLearningMode()
             P[21][21] = bodyMagFieldVar.z;
         } else {
             // set the variances equal to the observation variances
-            for (uint8_t index=18; index<=21; index++) {
+            for (uint8_t index=16; index<=21; index++) {
                 P[index][index] = sq(frontend->_magNoise);
             }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -180,6 +180,16 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
     }
 }
 
+// reset variances for mag body state
+void NavEKF2_core::resetMagBodyVariances(void)
+{
+    zeroCols(P,19,21);
+    zeroRows(P,19,21);
+    P[19][19] = sq(frontend->_magNoise);
+    P[20][20] = P[19][19];
+    P[21][21] = P[19][19];
+}
+
 // try changing to another compass
 void NavEKF2_core::tryChangeCompass(void)
 {
@@ -210,7 +220,11 @@ void NavEKF2_core::tryChangeCompass(void)
             magStateResetRequest = true;
             // declare the field unlearned so that the reset request will be obeyed
             magFieldLearned = false;
-            break;
+
+            // reset variances to learn again
+            resetMagBodyVariances();
+
+            return;
         }
     }
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -206,7 +206,7 @@ void NavEKF2_core::tryChangeCompass(void)
         // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
         if (compass->healthy(tempIndex) && compass->use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
             magSelectIndex = tempIndex;
-            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
+            gcs().send_text(MAV_SEVERITY_ALERT, "EKF2 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
             // reset the timeout flag and timer
             magTimeout = false;
             lastHealthyMagTime_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -180,6 +180,40 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
     }
 }
 
+// try changing to another compass
+void NavEKF2_core::tryChangeCompass(void)
+{
+    const auto *compass = _ahrs->get_compass();
+    const uint8_t maxCount = compass->get_count();
+
+    // search through the list of magnetometers
+    for (uint8_t i=1; i<maxCount; i++) {
+        uint8_t tempIndex = magSelectIndex + i;
+        // loop back to the start index if we have exceeded the bounds
+        if (tempIndex >= maxCount) {
+            tempIndex -= maxCount;
+        }
+        // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
+        if (compass->healthy(tempIndex) && compass->use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
+            magSelectIndex = tempIndex;
+            gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
+            // reset the timeout flag and timer
+            magTimeout = false;
+            lastHealthyMagTime_ms = imuSampleTime_ms;
+            // zero the learned magnetometer bias states
+            stateStruct.body_magfield.zero();
+            // clear the measurement buffer
+            storedMag.reset();
+            // clear the data waiting flag so that we do not use any data pending from the previous sensor
+            magDataToFuse = false;
+            // request a reset of the magnetic field states
+            magStateResetRequest = true;
+            // declare the field unlearned so that the reset request will be obeyed
+            magFieldLearned = false;
+            break;
+        }
+    }
+}
 
 /********************************************************
 *                      MAGNETOMETER                     *
@@ -200,43 +234,23 @@ void NavEKF2_core::readMagData()
         return;
     }
 
+    // check for failed compass
+    if (maxCount > 1 &&
+        !_ahrs->get_compass()->healthy(magSelectIndex) &&
+        imuSampleTime_ms - lastMagRead_ms > frontend->magFailTimeLimit_ms) {
+        tryChangeCompass();
+    }
+
     // do not accept new compass data faster than 14Hz (nominal rate is 10Hz) to prevent high processor loading
     // because magnetometer fusion is an expensive step and we could overflow the FIFO buffer
-    if (use_compass() && _ahrs->get_compass()->last_update_usec() - lastMagUpdate_us > 70000) {
+    if (use_compass() && _ahrs->get_compass()->last_update_usec(magSelectIndex) - lastMagUpdate_us > 70000) {
         frontend->logging.log_compass = true;
 
         // If the magnetometer has timed out (been rejected too long) we find another magnetometer to use if available
         // Don't do this if we are on the ground because there can be magnetic interference and we need to know if there is a problem
         // before taking off. Don't do this within the first 30 seconds from startup because the yaw error could be due to large yaw gyro bias affsets
         if (magTimeout && (maxCount > 1) && !onGround && imuSampleTime_ms - ekfStartTime_ms > 30000) {
-
-            // search through the list of magnetometers
-            for (uint8_t i=1; i<maxCount; i++) {
-                uint8_t tempIndex = magSelectIndex + i;
-                // loop back to the start index if we have exceeded the bounds
-                if (tempIndex >= maxCount) {
-                    tempIndex -= maxCount;
-                }
-                // if the magnetometer is allowed to be used for yaw and has a different index, we start using it
-                if (_ahrs->get_compass()->use_for_yaw(tempIndex) && tempIndex != magSelectIndex) {
-                    magSelectIndex = tempIndex;
-                    gcs().send_text(MAV_SEVERITY_INFO, "EKF2 IMU%u switching to compass %u",(unsigned)imu_index,magSelectIndex);
-                    // reset the timeout flag and timer
-                    magTimeout = false;
-                    lastHealthyMagTime_ms = imuSampleTime_ms;
-                    // zero the learned magnetometer bias states
-                    stateStruct.body_magfield.zero();
-                    // clear the measurement buffer
-                    storedMag.reset();
-                    // clear the data waiting flag so that we do not use any data pending from the previous sensor
-                    magDataToFuse = false;
-                    // request a reset of the magnetic field states
-                    magStateResetRequest = true;
-                    // declare the field unlearned so that the reset request will be obeyed
-                    magFieldLearned = false;
-                    break;
-                }
-            }
+            tryChangeCompass();
         }
 
         // detect changes to magnetometer offset parameters and reset states
@@ -268,6 +282,9 @@ void NavEKF2_core::readMagData()
 
         // save magnetometer measurement to buffer to be fused later
         storedMag.push(magDataNew);
+
+        // timestamp for checking failed compass
+        lastMagRead_ms = imuSampleTime_ms;
     }
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -958,6 +958,11 @@ void NavEKF2_core::CovariancePrediction()
         zeroRows(P,22,23);
         zeroCols(P,22,23);
     }
+    if (!inhibitMagStates && lastInhibitMagStates) {
+        // when we first start 3D fusion we want to use default variances
+        resetMagBodyVariances();
+    }
+    lastInhibitMagStates = inhibitMagStates;
 
     nextP[0][0] = daxNoise*SQ[3] + SPP[5]*(P[0][0]*SPP[5] - P[1][0]*SPP[4] + P[9][0]*SPP[22] + P[12][0]*SPP[18] + P[2][0]*(2*q1*SF[3] - 2*q2*SF[4] - 2*q3*SF[5] + 2*q0*SF[9])) - SPP[4]*(P[0][1]*SPP[5] - P[1][1]*SPP[4] + P[9][1]*SPP[22] + P[12][1]*SPP[18] + P[2][1]*(2*q1*SF[3] - 2*q2*SF[4] - 2*q3*SF[5] + 2*q0*SF[9])) + SPP[8]*(P[0][2]*SPP[5] + P[2][2]*SPP[8] + P[9][2]*SPP[22] + P[12][2]*SPP[18] - P[1][2]*(2*q0*SF[6] - 2*q3*SF[7] - 2*q1*SF[10] + 2*q2*SF[12])) + SPP[22]*(P[0][9]*SPP[5] - P[1][9]*SPP[4] + P[9][9]*SPP[22] + P[12][9]*SPP[18] + P[2][9]*(2*q1*SF[3] - 2*q2*SF[4] - 2*q3*SF[5] + 2*q0*SF[9])) + SPP[18]*(P[0][12]*SPP[5] - P[1][12]*SPP[4] + P[9][12]*SPP[22] + P[12][12]*SPP[18] + P[2][12]*(2*q1*SF[3] - 2*q2*SF[4] - 2*q3*SF[5] + 2*q0*SF[9]));
     nextP[0][1] = SPP[6]*(P[0][1]*SPP[5] - P[1][1]*SPP[4] + P[2][1]*SPP[8] + P[9][1]*SPP[22] + P[12][1]*SPP[18]) - SPP[2]*(P[0][0]*SPP[5] - P[1][0]*SPP[4] + P[2][0]*SPP[8] + P[9][0]*SPP[22] + P[12][0]*SPP[18]) + SPP[22]*(P[0][10]*SPP[5] - P[1][10]*SPP[4] + P[2][10]*SPP[8] + P[9][10]*SPP[22] + P[12][10]*SPP[18]) + SPP[17]*(P[0][13]*SPP[5] - P[1][13]*SPP[4] + P[2][13]*SPP[8] + P[9][13]*SPP[22] + P[12][13]*SPP[18]) - (2*q0*SF[5] - 2*q1*SF[4] - 2*q2*SF[3] + 2*q3*SF[9])*(P[0][2]*SPP[5] - P[1][2]*SPP[4] + P[2][2]*SPP[8] + P[9][2]*SPP[22] + P[12][2]*SPP[18]);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -608,6 +608,9 @@ private:
     // check for new altitude measurement data and update stored measurement if available
     void readBaroData();
 
+    // reset body mag variances
+    void resetMagBodyVariances(void);
+
     // try changing to another compass
     void tryChangeCompass();
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -869,6 +869,7 @@ private:
     float tasTestRatio;             // sum of squares of true airspeed innovation divided by fail threshold
     bool inhibitWindStates;         // true when wind states and covariances are to remain constant
     bool inhibitMagStates;          // true when magnetic field states and covariances are to remain constant
+    bool lastInhibitMagStates;      // previous inhibitMagStates
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     uint8_t last_gps_idx;           // sensor ID of the GPS receiver used for the last fusion or reset
     struct Location EKF_origin;     // LLH origin of the NED axis system

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -608,6 +608,9 @@ private:
     // check for new altitude measurement data and update stored measurement if available
     void readBaroData();
 
+    // try changing to another compass
+    void tryChangeCompass();
+
     // check for new magnetometer data and update store measurements if available
     void readMagData();
 
@@ -844,6 +847,7 @@ private:
     uint32_t timeAtLastAuxEKF_ms;   // last time the auxiliary filter was run to fuse range or optical flow measurements
     uint32_t secondLastGpsTime_ms;  // time of second last GPS fix used to determine how long since last update
     uint32_t lastHealthyMagTime_ms; // time the magnetometer was last declared healthy
+    uint32_t lastMagRead_ms;        // last successful read from mag
     bool allMagSensorsFailed;       // true if all magnetometer sensors have timed out on this flight and we are no longer using magnetometer data
     uint32_t lastYawTime_ms;        // time stamp when yaw observation was last fused (msec)
     uint32_t ekfStartTime_ms;       // time the EKF was started (msec)

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -159,6 +159,7 @@ const AP_Param::GroupInfo SITL::var_info2[] = {
     AP_GROUPINFO("GPS_DRIFT_S", 35, SITL,  gps_drift_spd, 0),
 
     AP_GROUPINFO("MAG_SCALING",    60, SITL,  mag_scaling, 1),
+    AP_GROUPINFO("MAG_FAIL_MSK",  61, SITL,  mag_fail_mask, 0),
 
     AP_GROUPEND
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -230,6 +230,9 @@ public:
     // weight on wheels pin
     AP_Int8 wow_pin;
 
+    // compass failure mask
+    AP_Int8 mag_fail_mask;
+
     // vibration frequencies in Hz on each axis
     AP_Vector3f vibe_freq;
 


### PR DESCRIPTION
This fixes two issues:
 - when a compass failed (stopped providing samples) we did not switch to the backup compass. We got away with this as the EKF, once converged, is able to fly for quite a long time without a compass.
 - when we change batteries between flights without rebooting the magnetic field of the vehicle could change. We should reset the mag body state variances when we are on the ground to ensure we can rapidly the changed field

Testing has been done in SITL with a test that flies two missions back to back without rebooting. The sequence is:
 - takeoff with deliberate X mag error of 100mGauss, fly a mission and land
 - change X mag offsets in SITL to zero and takeoff again. The EKF should learn the new field rapidly
 - part way through the 2nd flight fail the primary compass. The backup compass should be used, and it's offsets learned rapidly

Test logs before and after the fixes are here:
http://uav.tridgell.net/EKF/mag_offset_learn_sitl/

Without the fix we see this:
![image](https://user-images.githubusercontent.com/831867/93419103-3cd9cb80-f8ef-11ea-8705-3d10c757d9cc.png)
the initial offset learning is fine, and quickly approaches the correct value of 100mGauss. The learning on the 2nd flight is slow, and when the compass fails it stops learning altogether
with the fixes we get:
![image](https://user-images.githubusercontent.com/831867/93419145-6692f280-f8ef-11ea-8161-9144e42c6a72.png)
this shows rapidly learning in both flights, and correct handling of the compass failure
