### PR TITLE
AP_Arming: Fixed prearm alert message

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -145,7 +145,7 @@ void AP_Arming::check_failed(const enum AP_Arming::ArmingChecks check, bool repo
         return;
     }
     char taggedfmt[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
-    hal.util->snprintf((char*)taggedfmt, sizeof(taggedfmt)-1, "PreArm: %s", fmt);
+    hal.util->snprintf((char*)taggedfmt, sizeof(taggedfmt)-1, "PreArm check(s) failed");
     MAV_SEVERITY severity = check_severity(check);
     va_list arg_list;
     va_start(arg_list, fmt);


### PR DESCRIPTION
Empty pre arm alert message being generated by the Ardupilot. It was fixed by changing the pre-arm message such that it is more descriptive. More information can be found here:
https://matternet.atlassian.net/browse/NCT-1025
https://matternet.atlassian.net/browse/APM-62