### PR TITLE
AC_AttitudeControl: added WPNAV_XTRACK_MAX parameter

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -67,6 +67,14 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RFND_USE",   10, AC_WPNav, _rangefinder_use, 1),
 
+    // @Param: XTRACK_MAX
+    // @DisplayName: Waypoint crosstrack maximum
+    // @Description: This controls the maximum crosstrack distance in waypoint missions for fast waypoints. A value of zero means no limit
+    // @Range: 0 200
+    // @User: Advanced
+    // @Units: m
+    AP_GROUPINFO("XTRACK_MAX", 11, AC_WPNav, _crosstrack_max, 0),
+    
     AP_GROUPEND
 };
 
@@ -376,6 +384,16 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
 
     // check if target is already beyond the leash
     if (_track_desired > track_desired_max) {
+        reached_leash_limit = true;
+    }
+
+    /*
+      also check for crosstrack limit, allowing us to constrain leash
+      point to within a given distance of the track. This can be used
+      to prevent high wind from causing a blowout of the distance from
+      the desired track
+     */
+    if (_crosstrack_max > 0 && _track_error_xy*0.01 > _crosstrack_max) {
         reached_leash_limit = true;
     }
 

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -312,4 +312,5 @@ protected:
     AP_Int8     _rangefinder_use;
     bool        _rangefinder_healthy = false;
     float       _rangefinder_alt_cm = 0.0f;
+    AP_Float    _crosstrack_max;
 };


### PR DESCRIPTION
this allows the leash lateral error (the crosstrack) to be limited, which can help constrain
the path close to the desired waypoints in high wind

here is a SITL test with no limit:
![image](https://user-images.githubusercontent.com/831867/96333945-bb758480-10b8-11eb-8399-4966c79c12d3.png)

and here is the same wind simulation with WPNAV_XTRACK_MAX=30
![image](https://user-images.githubusercontent.com/831867/96333952-ccbe9100-10b8-11eb-985b-c3f4de3473f8.png)
