### PR TITLE
AP_GPS: Added GPS switching logic for the (missing) case when vehicle is armed

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -789,7 +789,13 @@ void AP_GPS::update(void)
                         should_switch = true;
                     }
                     
-                    else if (status_i == status_primary && !hal.util->get_soft_armed() && state[i].num_sats >= state[primary_instance].num_sats+3) {
+                    // When vehicle is Disarmed, and current primary GPS has 3 less satellites than the other one, switch to the other available GPS.
+                    else if (!hal.util->get_soft_armed() && status_i == status_primary && state[i].num_sats >= state[primary_instance].num_sats+3) {
+                        should_switch = true;                        
+                    }
+
+                    // When vehicle is Armed, and current primary GPS has 6 less satellites than the other one, switch to the other available GPS.
+                    else if (hal.util->get_soft_armed() && status_i == status_primary && state[i].num_sats >= state[primary_instance].num_sats+6) {
                         should_switch = true;                        
                     }
 


### PR DESCRIPTION
This build fixes the issue with the GPS switching logic, where the aircraft, when Armed, will not switch to the better GPS, if available. This missing case can cause trouble in rare edge cases where the currently chosen primary GPS tends to be showing a degraded performance, while the vehicle is in the air.
This PR is already reviewed before but made a new one, as the old PR had some other changes which are already merged in the master.  This PR is on top of the latest Ardupilot release (mttr-1.0.14).