### PR TITLE
support USER_1 mission item as failsafe jump

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -374,6 +374,7 @@ private:
 #endif
     void do_payload_place(const AP_Mission::Mission_Command& cmd);
     void do_RTL(void);
+    bool do_failsafe_jump(const AP_Mission::Mission_Command& cmd);
 
     bool verify_takeoff();
     bool verify_land();

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -533,6 +533,11 @@ bool Copter::ModeAuto::start_command(const AP_Mission::Mission_Command& cmd)
         break;
 #endif
 
+    case MAV_CMD_USER_1:
+        // used for conditional jump to waypoint based on failsafe condition
+        do_failsafe_jump(cmd);
+        break;
+
     default:
         // do nothing with unrecognized MAVLink messages
         break;
@@ -696,6 +701,9 @@ bool Copter::ModeAuto::verify_command(const AP_Mission::Mission_Command& cmd)
 
     case MAV_CMD_CONDITION_YAW:
         return verify_yaw();
+
+    case MAV_CMD_USER_1:
+        return do_failsafe_jump(cmd);
 
     // do commands (always return true)
     case MAV_CMD_DO_CHANGE_SPEED:
@@ -1930,6 +1938,31 @@ bool Copter::ModeAuto::verify_nav_delay(const AP_Mission::Mission_Command& cmd)
         nav_delay_time_max = 0;
         return true;
     }
+    return false;
+}
+
+/*
+  do a failsafe jump. This is like a DO_JUMP, but only jumps to the
+  target if we have not heard from the GCS for the given number of
+  seconds
+ */
+bool Copter::ModeAuto::do_failsafe_jump(const AP_Mission::Mission_Command& cmd)
+{
+    uint16_t jump_target = cmd.content.user_command.param1;
+
+    // we use a failsafe timeout of at least 2 seconds, to allow for some packet loss
+    float failsafe_timeout = MAX(2.0, cmd.content.user_command.param2);
+    float time_since_gcs_heartbeat = (AP_HAL::millis() - copter.failsafe.last_heartbeat_ms) * 0.001;
+
+    if (time_since_gcs_heartbeat <= failsafe_timeout) {
+        // nothing to do
+        return true;
+    }
+    if (copter.mission.set_current_cmd(jump_target)) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto: failsafe jump to %u", unsigned(jump_target));
+        return true;
+    }
+    gcs().send_text(MAV_SEVERITY_CRITICAL, "Auto: FAILED failsafe jump to %u", unsigned(jump_target));
     return false;
 }
 

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -877,6 +877,11 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
         cmd.content.winch.release_rate = packet.param4; // release rate in meters/second
         break;
 
+    case MAV_CMD_USER_1 ... MAV_CMD_USER_5:
+        cmd.content.user_command.param1 = packet.param1;
+        cmd.content.user_command.param2 = packet.param2;
+        break;
+        
     default:
         // unrecognised command
         return MAV_MISSION_UNSUPPORTED;
@@ -1331,6 +1336,11 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
         packet.param2 = cmd.content.winch.action;           // action (0 = relax, 1 = length control, 2 = rate control).  See WINCH_ACTION enum
         packet.param3 = cmd.content.winch.release_length;   // cable distance to unwind in meters, negative numbers to wind in cable
         packet.param4 = cmd.content.winch.release_rate;     // release rate in meters/second
+        break;
+
+    case MAV_CMD_USER_1 ... MAV_CMD_USER_5:
+        packet.param1 = cmd.content.user_command.param1;
+        packet.param2 = cmd.content.user_command.param2;
         break;
 
     default:
@@ -1799,6 +1809,9 @@ const char *AP_Mission::Mission_Command::type() const {
         return "SetROI";
     case MAV_CMD_DO_SET_REVERSE:
         return "SetReverse";
+    case MAV_CMD_USER_1:
+        return "USER";
+
     default:
         return "?";
     }

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -193,6 +193,12 @@ public:
         float release_rate;     // release rate in meters/second
     };
 
+    // nav user commands
+    struct PACKED User_Command {
+        float param1;
+        float param2;
+    };
+
     union PACKED Content {
         // jump structure
         Jump_Command jump;
@@ -257,6 +263,9 @@ public:
         // do-winch
         Winch_Command winch;
 
+        // user commands, for custom code
+        User_Command user_command;
+        
         // location
         Location location;      // Waypoint location
 


### PR DESCRIPTION
This does a conditional jump to a specified waypoint based on the time since the last GCS heartbeat. It is used to implement safe zones in the mission where landing sequences are conditionally started if the companion computer becomes unavailable
Here is an example mission:

![image](https://user-images.githubusercontent.com/831867/103499059-e2af4700-4e9a-11eb-9e18-0c4aac54d39b.png)

in this mission WP6 is the custom USER_1 mission item. That mission item takes two parameters:
 - param1 is the target of the conditional jump. It must be a valid WP number. In this case it points at WP8, which is a NAV_LOITER_TURNS waypoint
 -  param2 is the number of seconds that we got the last heartbeat from the GCS for us to not do the jump. The minimum value is 2 (a value below 2 will use 2). In this case we're using a value of 3.0, which means that if we pass this USER_1 waypoint and we haven't had a heartbeat from the GCS in the last 3 seconds then we will do the jump to WP 8.

Unlike a DO_JUMP there is no counter associated with a USER_1 conditional jump.

Some possible changes:
 - we could use an otherwise unused field of DO_JUMP instead if you prefer to give the timeout, with zero giving normal DO_JUMP behaviour

I've discussed with the ArduPilot multicopter lead @rmackay9 about including this feature in standard ArduPilot, and he would prefer that a lua script be used for the 4.0 or 4.1 version.
