### PR TITLE
AVX-107 set node ID in firmware

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/f303-ADSB/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f303-ADSB/hwdef.dat
@@ -117,8 +117,8 @@ define HAL_CAN_RX_QUEUE_SIZE 64
 
 define CAN_APP_NODE_NAME "com.matternet.trafficmonitor"
 
-# use DNA
-define HAL_CAN_DEFAULT_NODE_ID 0
+# hardcode Node ID to 125
+define HAL_CAN_DEFAULT_NODE_ID 125
 
 # ADSB enable
 #define ADSB_PORT 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/f303-USD1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f303-USD1/hwdef.dat
@@ -112,8 +112,7 @@ env ROMFS_UNCOMPRESSED True
 # reduce the number of CAN RX Buffer
 define HAL_CAN_RX_QUEUE_SIZE 64
 
-#define CAN_APP_NODE_NAME "com.matternet.ap_periph_rangefinder"
-define CAN_APP_NODE_NAME "com.matternet.USD1-Radar"
+define CAN_APP_NODE_NAME "org.ardupilot.USD1-Radar"
 
 # hardcode Node ID to 118
 define HAL_CAN_DEFAULT_NODE_ID 118

--- a/libraries/AP_HAL_ChibiOS/hwdef/f303-USD1/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/f303-USD1/hwdef.dat
@@ -115,8 +115,8 @@ define HAL_CAN_RX_QUEUE_SIZE 64
 #define CAN_APP_NODE_NAME "com.matternet.ap_periph_rangefinder"
 define CAN_APP_NODE_NAME "com.matternet.USD1-Radar"
 
-# use DNA
-define HAL_CAN_DEFAULT_NODE_ID 0
+# hardcode Node ID to 118
+define HAL_CAN_DEFAULT_NODE_ID 118
 
 define HAL_AIRSPEED_BUS_DEFAULT 0
 define AIRSPEED_MAX_SENSORS 1


### PR DESCRIPTION
- ADSB UAVCAN nodeID hardcoded to 125
- radar UAVCAN nodeID hardcoded to 118