### PR TITLE
Terrain failsafe land instead of RTL in events.cpp

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -197,17 +197,19 @@ void Copter::failsafe_terrain_set_status(bool data_ok)
 void Copter::failsafe_terrain_on_event()
 {
     failsafe.terrain = true;
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing");
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_TERRAIN, ERROR_CODE_FAILSAFE_OCCURRED);
 
     if (should_disarm_on_failsafe()) {
         init_disarm_motors();
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Disarming motors");
 #if MODE_RTL_ENABLED == ENABLED
     } else if (control_mode == RTL) {
         mode_rtl.restart_without_terrain();
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Restarting RTL without terrain");
 #endif
     } else {
-        set_mode_RTL_or_land_with_pause(MODE_REASON_TERRAIN_FAILSAFE);
+        set_mode_land_with_pause(MODE_REASON_TERRAIN_FAILSAFE);
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Setting flight mode to LAND");
     }
 }
 


### PR DESCRIPTION
Terrain failsafe currently results in a flight mode change to RTL.

The RTL path is not guaranteed to be along the planned flight path. SmartRTL was considered as an alternative but because the breadcrumbs it stores are a simplified variant of the flight path, it also cannot guarantee that the flight path is traced back to home without breaching geofence.

This PR introduces a change to set the flight mode to LAND in the event of terrain failsafe.

Terrain data support will be added in a later software system version.