### PR TITLE
AP_Rangefinder: change lightware lost signal timer from 1 to 20 (for mttr-4.0)

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -264,7 +264,7 @@ bool AP_RangeFinder_LightWareI2C::sf20_init()
     // When it is supported the expected response would be "e:1".
 
     // Changes the number of lost signal confirmations: 1 [1..250].
-    if (!sf20_send_and_expect("#LC,1\r\n", "lc:1")) {
+    if (!sf20_send_and_expect("#LC,20\r\n", "lc:20")) {
         return false;
     }
 


### PR DESCRIPTION
Porting the changes mentioned here: https://github.com/matternet/ardupilot/pull/141 to mttr-rebase-4.0. 