### PR TITLE
AC_WPNav: implement WPNAV_XTRACK_MAX (4.0 version)

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -67,6 +67,14 @@ const AP_Param::GroupInfo AC_WPNav::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RFND_USE",   10, AC_WPNav, _rangefinder_use, 1),
 
+    // @Param: XTRACK_MAX
+    // @DisplayName: Waypoint crosstrack maximum
+    // @Description: This controls the maximum crosstrack distance in waypoint missions for fast waypoints. A value of zero means no limit
+    // @Range: 0 200
+    // @User: Advanced
+    // @Units: m
+    AP_GROUPINFO("XTRACK_MAX", 11, AC_WPNav, _crosstrack_max, 0),
+    
     AP_GROUPEND
 };
 
@@ -364,6 +372,16 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
 
     // check if target is already beyond the leash
     if (_track_desired > track_desired_max) {
+        reached_leash_limit = true;
+    }
+
+    /*
+      also check for crosstrack limit, allowing us to constrain leash
+      point to within a given distance of the track. This can be used
+      to prevent high wind from causing a blowout of the distance from
+      the desired track
+     */
+    if (_crosstrack_max > 0 && _track_error_xy*0.01 > _crosstrack_max) {
         reached_leash_limit = true;
     }
 

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -320,4 +320,5 @@ protected:
     AP_Int8     _rangefinder_use;
     bool        _rangefinder_healthy;
     float       _rangefinder_alt_cm;
+    AP_Float    _crosstrack_max;
 };


### PR DESCRIPTION
this implements an optional lateral limit to the leash point to avoid
the crosstrack error growing beyond a given limit.

This is the 4.0 version of #131 
