### PR TITLE
Feature/mate 1561 parachute named int (mttr-rebase-4.0)

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -471,6 +471,10 @@ void Copter::one_hz_loop()
 #endif
 
     AP_Notify::flags.flying = !ap.land_complete;
+
+    if (copter.g2.dev_options.get() & DevOption_ParachuteMsg) {
+        gcs().send_named_int("PARACHUTE", int(parachute.released()));
+    }
 }
 
 // called at 50hz

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -153,6 +153,7 @@ enum PayloadPlaceStateType {
 enum DevOptions {
     DevOptionADSBMAVLink = 1,
     DevOptionVFR_HUDRelativeAlt = 2,
+    DevOption_ParachuteMsg = 4,
 };
 
 //  Logging parameters


### PR DESCRIPTION
Add a 1Hz NAMED_VALUE_INT message named PARACHUTE with a value corresponding to the state of the on-board parachute: 0: not deployed, 1: deployed.

The message reflects the parachute deployed state as reported by Ardupilot. The state changes to true only when AP releases the chute.