### PR TITLE
Feature/MATE-1579 Play tune upon mission load

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -362,6 +362,16 @@ void AP_Notify::handle_play_tune(mavlink_message_t *msg)
     }
 }
 
+// Have notify device play flight plan load tune
+void AP_Notify::play_flight_plan_load_tune()
+{
+    for (uint8_t i = 0; i < _num_devices; i++) {
+        if (_devices[i] != nullptr) {
+            _devices[i]->play_flight_plan_load_tune();
+        }
+    }
+}
+
 // set flight mode string
 void AP_Notify::set_flight_mode_str(const char *str)
 {

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -139,6 +139,7 @@ public:
     // handle a PLAY_TUNE message
     static void handle_play_tune(mavlink_message_t* msg);
 
+    // play tune upon flight plan load
     static void play_flight_plan_load_tune();
 
     bool buzzer_enabled() const { return _buzzer_enable; }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -139,6 +139,8 @@ public:
     // handle a PLAY_TUNE message
     static void handle_play_tune(mavlink_message_t* msg);
 
+    static void play_flight_plan_load_tune();
+
     bool buzzer_enabled() const { return _buzzer_enable; }
 
     // set flight mode string

--- a/libraries/AP_Notify/NotifyDevice.h
+++ b/libraries/AP_Notify/NotifyDevice.h
@@ -19,6 +19,9 @@ public:
 
     // handle a PLAY_TUNE message, by default device ignore message
     virtual void handle_play_tune(mavlink_message_t *msg) {}
+
+    // play tune upon flight plan load
+    virtual void play_flight_plan_load_tune(); 
     
     // this pointer is used to read the parameters relative to devices
     const AP_Notify *pNotify;

--- a/libraries/AP_Notify/NotifyDevice.h
+++ b/libraries/AP_Notify/NotifyDevice.h
@@ -21,7 +21,7 @@ public:
     virtual void handle_play_tune(mavlink_message_t *msg) {}
 
     // play tune upon flight plan load
-    virtual void play_flight_plan_load_tune(); 
+    virtual void play_flight_plan_load_tune() {} 
     
     // this pointer is used to read the parameters relative to devices
     const AP_Notify *pNotify;

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -95,7 +95,6 @@ const AP_ToneAlarm::Tone AP_ToneAlarm::_tones[] {
     { "MNBGG", false },
 #define AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD 31
     { "MFT220 ML O3ef O4c", true },
-"}
 };
 
 bool AP_ToneAlarm::init()

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -93,6 +93,9 @@ const AP_ToneAlarm::Tone AP_ToneAlarm::_tones[] {
     { "MFMST200L64O4ceceP32ceceP8df#df#P32df#df#P8L16gf#g>c", false },
 #define AP_NOTIFY_TONE_NO_SDCARD 30
     { "MNBGG", false },
+#define AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD 31
+    { "MFT220 ML O3ef O4c", true },
+"}
 };
 
 bool AP_ToneAlarm::init()
@@ -160,6 +163,11 @@ void AP_ToneAlarm::_timer_task()
         _mml_player.update();
         _sem->give();
     }
+}
+
+void AP_ToneAlarm::play_flight_plan_load_tune()
+{
+    play_tone(AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD);
 }
 
 void AP_ToneAlarm::play_string(const char *str)

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -164,11 +164,6 @@ void AP_ToneAlarm::_timer_task()
     }
 }
 
-void AP_ToneAlarm::play_flight_plan_load_tune()
-{
-    play_tone(AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD);
-}
-
 void AP_ToneAlarm::play_string(const char *str)
 {
     if (_sem && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
@@ -438,4 +433,12 @@ void AP_ToneAlarm::handle_play_tune(mavlink_message_t *msg)
         _mml_player.play(_tone_buf);
         _sem->give();
     }
+}
+
+/*
+ * Play pre-defined AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD tone from _tones
+ */
+void AP_ToneAlarm::play_flight_plan_load_tune()
+{
+    play_tone(AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD);
 }

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -35,6 +35,8 @@ public:
     // handle a PLAY_TUNE message
     void handle_play_tune(mavlink_message_t *msg);
 
+    void play_flight_plan_load_tune();
+
 private:
     /// play_tune - play one of the pre-defined tunes
     void play_tone(const uint8_t tone_index);

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -35,6 +35,7 @@ public:
     // handle a PLAY_TUNE message
     void handle_play_tune(mavlink_message_t *msg);
 
+    // play AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD from list of tones
     void play_flight_plan_load_tune();
 
 private:

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -22,6 +22,7 @@
 #include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_Common/AP_FWVersion.h>
+#include <AP_Notify/ToneAlarm.h>
 
 // check if a message will fit in the payload space available
 #define PAYLOAD_SIZE(chan, id) (GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -22,7 +22,6 @@
 #include <AP_AdvancedFailsafe/AP_AdvancedFailsafe.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_Common/AP_FWVersion.h>
-#include <AP_Notify/ToneAlarm.h>
 
 // check if a message will fit in the payload space available
 #define PAYLOAD_SIZE(chan, id) (GCS_MAVLINK::packet_overhead_chan(chan)+MAVLINK_MSG_ID_ ## id ## _LEN)

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -23,8 +23,8 @@
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_BLHeli/AP_BLHeli.h>
 #include <AP_Parachute/AP_Parachute.h>
+#include <AP_Notify/ToneAlarm.h>
 
-#include "ToneAlarm.h"
 #include "GCS.h"
 
 #include <stdio.h>

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -50,6 +50,7 @@ uint32_t GCS_MAVLINK::last_radio_status_remrssi_ms;
 uint8_t GCS_MAVLINK::mavlink_active = 0;
 uint8_t GCS_MAVLINK::chan_is_streaming = 0;
 uint32_t GCS_MAVLINK::reserve_param_space_start_ms;
+std::string GCS_MAVLINK::flight_plan_load_tune = "MFT220 ML O3ef O4c";
 
 GCS *GCS::_singleton = nullptr;
 
@@ -777,9 +778,13 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         mission_is_complete = true;
         // XXX ignores waypoint radius for individual waypoints, can
         // only set WP_RADIUS parameter
+
         // Play tune to notify pilot that flight plan was received and loaded
-        std::string tune = "MFT220 ML O3ef O4c";
-        play_string(tune.c_str());
+        // IFF disarmed to prevent tune from playing when partial waypoint
+        // update occurs while armed and in flight
+        if (!hal.util->get_soft_armed())  {
+            play_string(flight_plan_load_tune.c_str());
+        }
     } else {
         waypoint_timelast_request = AP_HAL::millis();
         // if we have enough space, then send the next WP immediately

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -776,6 +776,9 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         mission_is_complete = true;
         // XXX ignores waypoint radius for individual waypoints, can
         // only set WP_RADIUS parameter
+        // Play tune to notify pilot that flight plan was received and loaded
+        std::string tune = "MFT220 ML O3ef O4c";
+        play_string(tune.c_str());
     } else {
         waypoint_timelast_request = AP_HAL::millis();
         // if we have enough space, then send the next WP immediately

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -781,7 +781,10 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         // Play tune to notify pilot that flight plan was received and loaded.
         // play_tone(), called by play_flight_plan_load_tune(),
         // prevents playing if armed
-        AP_ToneAlarm::play_flight_plan_load_tune();
+        AP_Notify *notify = AP_Notify::instance();
+        if (notify) {
+            notify->play_flight_plan_load_tune(text);
+        }
     } else {
         waypoint_timelast_request = AP_HAL::millis();
         // if we have enough space, then send the next WP immediately

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -23,7 +23,6 @@
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_BLHeli/AP_BLHeli.h>
 #include <AP_Parachute/AP_Parachute.h>
-#include <AP_Notify/ToneAlarm.h>
 
 #include "GCS.h"
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -24,6 +24,7 @@
 #include <AP_BLHeli/AP_BLHeli.h>
 #include <AP_Parachute/AP_Parachute.h>
 
+#include "ToneAlarm.h"
 #include "GCS.h"
 
 #include <stdio.h>

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -783,7 +783,7 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         // IFF disarmed to prevent tune from playing when partial waypoint
         // update occurs while armed and in flight
         if (!hal.util->get_soft_armed())  {
-            play_string(flight_plan_load_tune.c_str());
+            AP_ToneAlarm::play_string(flight_plan_load_tune.c_str());
         }
     } else {
         waypoint_timelast_request = AP_HAL::millis();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -780,10 +780,7 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         // Play tune to notify pilot that flight plan was received and loaded.
         // play_tone(), called by play_flight_plan_load_tune(),
         // prevents playing if armed
-        AP_Notify *notify = AP_Notify::instance();
-        if (notify) {
-            notify->play_flight_plan_load_tune(text);
-        }
+        AP_Notify::play_flight_plan_load_tune();
     } else {
         waypoint_timelast_request = AP_HAL::millis();
         // if we have enough space, then send the next WP immediately

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -50,7 +50,6 @@ uint32_t GCS_MAVLINK::last_radio_status_remrssi_ms;
 uint8_t GCS_MAVLINK::mavlink_active = 0;
 uint8_t GCS_MAVLINK::chan_is_streaming = 0;
 uint32_t GCS_MAVLINK::reserve_param_space_start_ms;
-std::string GCS_MAVLINK::flight_plan_load_tune = "MFT220 ML O3ef O4c";
 
 GCS *GCS::_singleton = nullptr;
 
@@ -779,12 +778,10 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         // XXX ignores waypoint radius for individual waypoints, can
         // only set WP_RADIUS parameter
 
-        // Play tune to notify pilot that flight plan was received and loaded
-        // IFF disarmed to prevent tune from playing when partial waypoint
-        // update occurs while armed and in flight
-        if (!hal.util->get_soft_armed())  {
-            AP_ToneAlarm::play_string(flight_plan_load_tune.c_str());
-        }
+        // Play tune to notify pilot that flight plan was received and loaded.
+        // play_tone(), called by play_flight_plan_load_tune(),
+        // prevents playing if armed
+        AP_ToneAlarm::play_flight_plan_load_tune();
     } else {
         waypoint_timelast_request = AP_HAL::millis();
         // if we have enough space, then send the next WP immediately


### PR DESCRIPTION
Removes play tune send message from MATE, which would intermittently drop. Adds new tune to `_tones` and plays tune when last mission item from GCS is received. Barrier in `play_tone` prevents tune from playing while armed.