### PR TITLE
GCS_MAVLink: play a tune on completion of waypoint load (4.0 version)

### DIFF
--- a/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol_Waypoints.cpp
@@ -23,6 +23,8 @@
 
 #include "GCS.h"
 
+extern const AP_HAL::HAL& hal;
+
 MAV_MISSION_RESULT MissionItemProtocol_Waypoints::append_item(const mavlink_mission_item_int_t &mission_item_int)
 {
     // sanity check for DO_JUMP command
@@ -54,6 +56,12 @@ MAV_MISSION_RESULT MissionItemProtocol_Waypoints::complete(const GCS_MAVLINK &_l
 {
     _link.send_text(MAV_SEVERITY_INFO, "Flight plan received");
     AP::logger().Write_EntireMission();
+
+    if (!hal.util->get_soft_armed()) {
+        // play a tune to signify completion of wp upload
+        AP::notify().play_tune("MFT220 ML O3ef O4c");
+    }
+
     return MAV_MISSION_ACCEPTED;
 }
 


### PR DESCRIPTION
this is a 4.0 version of #162 
Note that 4.0 has a play_tune() public notify method, so it is much simpler
Also note that for testing in 4.0 you can use the --tonealarm option to sim_vehicle.py to simulate the buzzer in SITL
