### PR TITLE
Feature/MATE-1579 Play tune on mission waypoint load (3.6.7)

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -362,6 +362,16 @@ void AP_Notify::handle_play_tune(mavlink_message_t *msg)
     }
 }
 
+// Have notify device play flight plan load tune
+void AP_Notify::play_flight_plan_load_tune()
+{
+    for (uint8_t i = 0; i < _num_devices; i++) {
+        if (_devices[i] != nullptr) {
+            _devices[i]->play_flight_plan_load_tune();
+        }
+    }
+}
+
 // set flight mode string
 void AP_Notify::set_flight_mode_str(const char *str)
 {

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -139,6 +139,9 @@ public:
     // handle a PLAY_TUNE message
     static void handle_play_tune(mavlink_message_t* msg);
 
+    // play tune upon flight plan load
+    static void play_flight_plan_load_tune();
+
     bool buzzer_enabled() const { return _buzzer_enable; }
 
     // set flight mode string

--- a/libraries/AP_Notify/NotifyDevice.h
+++ b/libraries/AP_Notify/NotifyDevice.h
@@ -19,6 +19,9 @@ public:
 
     // handle a PLAY_TUNE message, by default device ignore message
     virtual void handle_play_tune(mavlink_message_t *msg) {}
+
+    // play tune upon flight plan load
+    virtual void play_flight_plan_load_tune() {} 
     
     // this pointer is used to read the parameters relative to devices
     const AP_Notify *pNotify;

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -93,6 +93,8 @@ const AP_ToneAlarm::Tone AP_ToneAlarm::_tones[] {
     { "MFMST200L64O4ceceP32ceceP8df#df#P32df#df#P8L16gf#g>c", false },
 #define AP_NOTIFY_TONE_NO_SDCARD 30
     { "MNBGG", false },
+#define AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD 31
+    { "MFT220 ML O3ef O4c", false },
 };
 
 bool AP_ToneAlarm::init()
@@ -431,4 +433,12 @@ void AP_ToneAlarm::handle_play_tune(mavlink_message_t *msg)
         _mml_player.play(_tone_buf);
         _sem->give();
     }
+}
+
+/*
+ * Play pre-defined AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD tone from _tones
+ */
+void AP_ToneAlarm::play_flight_plan_load_tune()
+{
+    play_tone(AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD);
 }

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -35,6 +35,9 @@ public:
     // handle a PLAY_TUNE message
     void handle_play_tune(mavlink_message_t *msg);
 
+    // play AP_NOTIFY_TONE_FLIGHT_PLAN_LOAD from list of tones
+    void play_flight_plan_load_tune();
+
 private:
     /// play_tune - play one of the pre-defined tunes
     void play_tone(const uint8_t tone_index);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -776,6 +776,11 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         mission_is_complete = true;
         // XXX ignores waypoint radius for individual waypoints, can
         // only set WP_RADIUS parameter
+
+        // Play tune to notify pilot that flight plan was received and loaded.
+        // play_tone(), called by play_flight_plan_load_tune(),
+        // prevents playing if armed
+        AP_Notify::play_flight_plan_load_tune();
     } else {
         waypoint_timelast_request = AP_HAL::millis();
         // if we have enough space, then send the next WP immediately


### PR DESCRIPTION
Re-issuance of https://github.com/matternet/ardupilot/pull/162/files with corrected commit syntax.

Description:
Removes play tune send message from MATE, which would intermittently drop. Adds new tune to _tones and plays tune when last mission item from GCS is received. Barrier in play_tone prevents tune from playing while armed.