### PR TITLE
Play a tune for wp load complete (3.6 version)

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -362,6 +362,15 @@ void AP_Notify::handle_play_tune(mavlink_message_t *msg)
     }
 }
 
+void AP_Notify::play_tune(const char *tune)
+{
+    for (uint8_t i = 0; i < _num_devices; i++) {
+        if (_devices[i] != nullptr) {
+            _devices[i]->play_tune(tune);
+        }
+    }
+}
+
 // set flight mode string
 void AP_Notify::set_flight_mode_str(const char *str)
 {
@@ -375,3 +384,12 @@ void AP_Notify::send_text(const char *str)
     _send_text[sizeof(_send_text)-1] = 0;
     _send_text_updated_millis = AP_HAL::millis();
 }
+
+namespace AP {
+
+AP_Notify &notify()
+{
+    return *AP_Notify::instance();
+}
+
+};

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -139,6 +139,9 @@ public:
     // handle a PLAY_TUNE message
     static void handle_play_tune(mavlink_message_t* msg);
 
+    // play a tune string
+    static void play_tune(const char *tune);
+
     bool buzzer_enabled() const { return _buzzer_enable; }
 
     // set flight mode string
@@ -177,4 +180,8 @@ private:
 
     static NotifyDevice* _devices[];
     static uint8_t _num_devices;
+};
+
+namespace AP {
+    AP_Notify &notify();
 };

--- a/libraries/AP_Notify/NotifyDevice.h
+++ b/libraries/AP_Notify/NotifyDevice.h
@@ -19,6 +19,9 @@ public:
 
     // handle a PLAY_TUNE message, by default device ignore message
     virtual void handle_play_tune(mavlink_message_t *msg) {}
+
+    // play a MML tune
+    virtual void play_tune(const char *tune) {}
     
     // this pointer is used to read the parameters relative to devices
     const AP_Notify *pNotify;

--- a/libraries/AP_Notify/ToneAlarm.cpp
+++ b/libraries/AP_Notify/ToneAlarm.cpp
@@ -151,7 +151,7 @@ void AP_ToneAlarm::play_tone(const uint8_t tone_index)
     _tone_playing = tone_index;
     _tone_beginning_ms = tnow_ms;
 
-    play_string(tone_requested.str);
+    play_tune(tone_requested.str);
 }
 
 void AP_ToneAlarm::_timer_task()
@@ -162,7 +162,7 @@ void AP_ToneAlarm::_timer_task()
     }
 }
 
-void AP_ToneAlarm::play_string(const char *str)
+void AP_ToneAlarm::play_tune(const char *str)
 {
     if (_sem && _sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         _mml_player.stop();
@@ -176,7 +176,7 @@ void AP_ToneAlarm::play_string(const char *str)
 void AP_ToneAlarm::stop_cont_tone()
 {
     if (_cont_tone_playing == _tone_playing) {
-        play_string("");
+        play_tune("");
         _tone_playing = -1;
     }
     _cont_tone_playing = -1;

--- a/libraries/AP_Notify/ToneAlarm.h
+++ b/libraries/AP_Notify/ToneAlarm.h
@@ -35,12 +35,12 @@ public:
     // handle a PLAY_TUNE message
     void handle_play_tune(mavlink_message_t *msg);
 
+    // play_tune - play tone specified by the provided string of notes
+    void play_tune(const char *tune) override;
+
 private:
     /// play_tune - play one of the pre-defined tunes
     void play_tone(const uint8_t tone_index);
-
-    // play_string - play tone specified by the provided string of notes
-    void play_string(const char *str);
 
     // stop_cont_tone - stop playing the currently playing continuous tone
     void stop_cont_tone();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -774,6 +774,12 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         send_text(MAV_SEVERITY_INFO,"Flight plan received");
         waypoint_receiving = false;
         mission_is_complete = true;
+
+        if (!hal.util->get_soft_armed()) {
+            // play a tune to signify completion of wp upload
+            AP::notify().play_tune("MFT220 ML O3ef O4c");
+        }
+
         // XXX ignores waypoint radius for individual waypoints, can
         // only set WP_RADIUS parameter
     } else {


### PR DESCRIPTION
This is 3.6 version of #163 
It includes a backport of the original PR adding play_tune and exposing AP_Notify as a singleton
Note: this has not been tested (I have no access to test hardware at the moment). See news about floods in Australia for why :-)
