### PR TITLE
Terrain failsafe land instead of RTL in events.cpp

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -274,7 +274,7 @@ void Copter::failsafe_terrain_on_event()
         gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Restarting RTL without terrain");
 #endif
     } else {
-        set_mode_land_with_pause(MODE_REASON_TERRAIN_FAILSAFE);
+        set_mode_land_with_pause(ModeReason::TERRAIN_FAILSAFE);
         gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Setting flight mode to LAND");
     }
 }

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -263,17 +263,19 @@ void Copter::failsafe_terrain_set_status(bool data_ok)
 void Copter::failsafe_terrain_on_event()
 {
     failsafe.terrain = true;
-    gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing");
     AP::logger().Write_Error(LogErrorSubsystem::FAILSAFE_TERRAIN, LogErrorCode::FAILSAFE_OCCURRED);
 
     if (should_disarm_on_failsafe()) {
         arming.disarm();
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Disarming motors");
 #if MODE_RTL_ENABLED == ENABLED
     } else if (control_mode == Mode::Number::RTL) {
         mode_rtl.restart_without_terrain();
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Restarting RTL without terrain");
 #endif
     } else {
-        set_mode_RTL_or_land_with_pause(ModeReason::TERRAIN_FAILSAFE);
+        set_mode_land_with_pause(MODE_REASON_TERRAIN_FAILSAFE);
+        gcs().send_text(MAV_SEVERITY_CRITICAL,"Failsafe: Terrain data missing. Setting flight mode to LAND");
     }
 }
 


### PR DESCRIPTION
Terrain failsafe currently results in a flight mode change to RTL.

The RTL path is not guaranteed to be along the planned flight path. SmartRTL was considered as an alternative but because the breadcrumbs it stores are a simplified variant of the flight path, it also cannot guarantee that the flight path is traced back to home without breaching geofence.

This PR introduces a change to set the flight mode to LAND in the event of terrain failsafe.

Terrain data support will be added in a later software system version.

3.6.7 PR: https://github.com/matternet/ardupilot/pull/147