### PR TITLE
AP_GPS: fixed nullptr deref for dual-GPS (4.0 version)

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -949,13 +949,14 @@ void AP_GPS::update_primary(void)
 
     // handle switch between real GPSs
     for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
-        if (i == primary_instance) {
+        if (i == primary_instance || drivers[i] == nullptr) {
             continue;
         }
 
         // if primary is not a F9 and altternative is a F9 with 3D fix then use the F9
         if (state[i].status >= GPS_OK_FIX_3D &&
             strcmp(drivers[i]->name(), "u-blox") == 0 && drivers[i]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9 &&
+            drivers[primary_instance] != nullptr &&
             strcmp(drivers[primary_instance]->name(), "u-blox") == 0 && drivers[primary_instance]->hardware_generation() != AP_GPS_UBLOX::UBLOX_F9) {
             primary_instance = i;
             _last_instance_swap_ms = now;
@@ -964,6 +965,7 @@ void AP_GPS::update_primary(void)
 
         // if primary F9 has 3D lock, and 2nd GPS is a M8, don't switch
         if (state[primary_instance].status >= GPS_OK_FIX_3D &&
+            drivers[primary_instance] != nullptr &&
             strcmp(drivers[primary_instance]->name(), "u-blox") == 0 && drivers[primary_instance]->hardware_generation() == AP_GPS_UBLOX::UBLOX_F9 &&
             strcmp(drivers[i]->name(), "u-blox") == 0 && drivers[i]->hardware_generation() != AP_GPS_UBLOX::UBLOX_F9) {
             // don't switch away from a F9 with 3D lock to a M8


### PR DESCRIPTION
the patch for the special case for F9 handling could dereference
nullptr, resulting in a watchdog