### PR TITLE
Copter: display watchdog information in mavlink

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -475,6 +475,26 @@ void Copter::one_hz_loop()
     if (copter.g2.dev_options.get() & DevOption_ParachuteMsg) {
         gcs().send_named_int("PARACHUTE", int(parachute.released()));
     }
+
+    if (hal.util->was_watchdog_reset()) {
+        const AP_HAL::Util::PersistentData &pd = hal.util->last_persistent_data;
+        gcs().send_text(MAV_SEVERITY_CRITICAL,
+                        "WDG: T%d SL%u FL%u FT%u FA%x FTP%u FLR%x FICSR%u MM%u MC%u IE%u IEC%u TN:%.4s",
+                        pd.scheduler_task,
+                        pd.semaphore_line,
+                        pd.fault_line,
+                        pd.fault_type,
+                        (unsigned)pd.fault_addr,
+                        pd.fault_thd_prio,
+                        (unsigned)pd.fault_lr,
+                        (unsigned)pd.fault_icsr,
+                        pd.last_mavlink_msgid,
+                        pd.last_mavlink_cmd,
+                        (unsigned)pd.internal_errors,
+                        (unsigned)pd.internal_error_count,
+                        pd.thread_name4
+            );
+    }
 }
 
 // called at 50hz


### PR DESCRIPTION
this helps track down watchdog issues without onboard logs
Note that you can test this with recent mavproxy like this:

  lockup_autopilot IREALLYMEANIT

You will get messages like this:
```
WDG: T31 SL0 FL0 FT0 FA0 FTP0 FLR0 FICSR0 MM0 MC24
```
