### PR TITLE
Copter events.cpp: Remove FS_GCS_DISABLED check in RC failsafe

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -69,9 +69,8 @@ void Copter::failsafe_radio_on_event()
         desired_action = Failsafe_Action_None;
 
     } else if ((flightmode->in_guided_mode()) &&
-      (failsafe_option(FailsafeOption::RC_CONTINUE_IF_GUIDED)) && (g.failsafe_gcs != FS_GCS_DISABLED)) {
-        // Allow guided mode to continue when FS_OPTIONS is set to continue in guided mode.  Only if the GCS failsafe is enabled.
-        gcs().send_text(MAV_SEVERITY_WARNING, "Radio Failsafe - Continuing Guided Mode");
+      (failsafe_option(FailsafeOption::RC_CONTINUE_IF_GUIDED))) {
+        // Allow guided mode to continue when FS_OPTIONS is set to continue in guided mode
         desired_action = Failsafe_Action_None;
 
     } else {


### PR DESCRIPTION
Currently when the aircraft is armed in GUIDED mode without a RC powered on, the aircraft automatically disarms with the message "Radio Failsafe" due to the check for not FS_GCS_DISABLED failing since our configuration has GCS FS disabled.

This PR removes the FS_GCS_DISABLED requirement for RC failsafe disarm when the aircraft is armed in GUIDED mode.