### PR TITLE
AVX-284 Output SNR from radar

### DIFF
--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -1885,6 +1885,13 @@ void AP_Periph_FW::can_rangefinder_update(void)
     pkt.range = dist_cm * 0.01;
     fix_float16(pkt.range);
 
+    // "field of view" is currently not used.  So for US-D1 radar, we will
+    // overload this field with SNR
+    if (rangefinder.get_type(0) == RangeFinder::Type::ULANDING) {
+        pkt.field_of_view = (float) rangefinder.snr(ROTATION_NONE);
+        fix_float16(pkt.field_of_view);
+    }
+
     uint8_t buffer[UAVCAN_EQUIPMENT_RANGE_SENSOR_MEASUREMENT_MAX_SIZE] {};
     uint16_t total_size = uavcan_equipment_range_sensor_Measurement_encode(&pkt, buffer);
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1938,14 +1938,14 @@ struct PACKED log_PSC {
       "BAT", "QBfffffcf", "TimeUS,Instance,Volt,VoltR,Curr,CurrTot,EnrgTot,Temp,Res", "s#vvAiJOw", "F-000!/?0" },  \
     { LOG_CURRENT_CELLS_MSG, sizeof(log_Current_Cells), \
       "BCL", "QBfHHHHHHHHHHHH", "TimeUS,Instance,Volt,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12", "s#vvvvvvvvvvvvv", "F-0CCCCCCCCCCCC" }, \
-	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
+	  { LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCCB", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw,AEKF", "sddddhhdh-", "FBBBBBBBB-" }, \
     { LOG_MAG_MSG, sizeof(log_MAG), \
       "MAG", "QBhhhhhhhhhBI",    "TimeUS,I,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOX,MOY,MOZ,Health,S", "s#GGGGGGGGG-s", "F-CCCCCCCCC-F" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
-      "RFND", "QBCBB", "TimeUS,Instance,Dist,Snr,Stat,Orient", "s#m--", "F-B--" }, \
+      "RFND", "QBCCBB", "TimeUS,Instance,Dist,Snr,Stat,Orient", "s#m---", "F-B---" }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     { LOG_BEACON_MSG, sizeof(log_Beacon), \

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -618,6 +618,7 @@ struct PACKED log_RFND {
     uint64_t time_us;
     uint8_t instance;
     uint16_t dist;
+    uint16_t snr;
     uint8_t status;
     uint8_t orient;
 };

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1710,6 +1710,7 @@ struct PACKED log_PSC {
 // @Field: TimeUS: Time since system startup
 // @Field: Instance: rangefinder instance number this data is from
 // @Field: Dist: Reported distance from sensor
+// @Field: Snr: Signal-to-noise ratio
 // @Field: Stat: Sensor state
 // @Field: Orient: Sensor orientation
 
@@ -1944,7 +1945,7 @@ struct PACKED log_PSC {
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
-      "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--" }, \
+      "RFND", "QBCBB", "TimeUS,Instance,Dist,Snr,Stat,Orient", "s#m--", "F-B--" }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     { LOG_BEACON_MSG, sizeof(log_Beacon), \

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -658,6 +658,15 @@ AP_RangeFinder_Backend *RangeFinder::find_instance(enum Rotation orientation) co
     return nullptr;
 }
 
+uint16_t RangeFinder::snr(enum Rotation orientation) const
+{
+    AP_RangeFinder_Backend *backend = find_instance(orientation);
+    if (backend == nullptr) {
+        return 0;
+    }
+    return backend->snr();
+}
+
 uint16_t RangeFinder::distance_cm_orient(enum Rotation orientation) const
 {
     AP_RangeFinder_Backend *backend = find_instance(orientation);
@@ -762,6 +771,7 @@ void RangeFinder::Log_RFND()
                 time_us      : AP_HAL::micros64(),
                 instance     : i,
                 dist         : s->distance_cm(),
+                snr          : s->snr(),
                 status       : (uint8_t)s->status(),
                 orient       : s->orientation(),
         };

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -109,6 +109,7 @@ public:
     struct RangeFinder_State {
         uint16_t distance_cm;           // distance: in cm
         uint16_t voltage_mv;            // voltage in millivolts, if applicable, otherwise 0
+        uint16_t snr;                    // snr, if applicable, otherwise 0
         enum RangeFinder::Status status; // sensor status
         uint8_t  range_valid_count;     // number of consecutive valid readings (maxes out at 10)
         uint32_t last_reading_ms;       // system time of last successful update from sensor
@@ -180,6 +181,8 @@ public:
     uint8_t range_valid_count_orient(enum Rotation orientation) const;
     const Vector3f &get_pos_offset_orient(enum Rotation orientation) const;
     uint32_t last_reading_ms(enum Rotation orientation) const;
+
+    uint16_t snr(enum Rotation orientation) const;
 
     /*
       set an externally estimated terrain height. Used to enable power

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -38,6 +38,8 @@ public:
 
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }
+    uint16_t snr() const { return state.snr; }
+    void snr(uint16_t snr) { state.snr = snr; }
     uint16_t voltage_mv() const { return state.voltage_mv; }
     virtual int16_t max_distance_cm() const { return params.max_distance_cm; }
     virtual int16_t min_distance_cm() const { return params.min_distance_cm; }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.cpp
@@ -21,6 +21,7 @@ void AP_RangeFinder_USD1_CAN::update(void)
         set_status(RangeFinder::Status::NoData);
     } else if (new_data) {
         state.distance_cm = _distance_cm;
+        state.snr = _snr;
         state.last_reading_ms = _last_reading_ms;
         update_status();
         new_data = false;
@@ -32,6 +33,7 @@ void AP_RangeFinder_USD1_CAN::handle_frame(AP_HAL::CANFrame &frame)
 {
     WITH_SEMAPHORE(_sem);
     _distance_cm = (frame.data[0]<<8) | frame.data[1];
+    _snr = (frame.data[2]<<8) | frame.data[3];
     _last_reading_ms = AP_HAL::millis();
     new_data = true;
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_USD1_CAN.h
@@ -21,6 +21,7 @@ protected:
 private:
     bool new_data;
     uint16_t _distance_cm;
+    uint16_t _snr;
     uint32_t _last_reading_ms;
 };
 #endif //HAL_MAX_CAN_PROTOCOL_DRIVERS

--- a/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_uLanding.cpp
@@ -118,6 +118,7 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
 
     // read any available lines from the uLanding
     float sum = 0;
+    uint16_t sum2 = 0;
     uint16_t count = 0;
     bool hdr_found = false;
 
@@ -151,6 +152,7 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
                     if (((_linebuf[1] + _linebuf[2] + _linebuf[3] + _linebuf[4]) & 0xFF) == _linebuf[5]) {
                         // if checksum passed, parse data for Firmware Version #1
                         sum += _linebuf[3]*256 + _linebuf[2];
+                        sum2 += _linebuf[4];
                         count++;
                     }
                 }
@@ -166,6 +168,7 @@ bool AP_RangeFinder_uLanding::get_reading(uint16_t &reading_cm)
     }
 
     reading_cm = sum / count;
+    this->snr(sum2/count);
 
     if (_version == 0 && _header != ULANDING_HDR) {
         reading_cm *= 2.5f;


### PR DESCRIPTION
- parsed radar data for SNR
- output SNR via overloaded "field_of_view" in uavcan.equipment.range_sensor.Measurement (id: 1050)
- limited SNR output to US-D1 radar