### PR TITLE
HAL_ChibiOS: run storage writes at 1kHz not 100Hz

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -492,7 +492,7 @@ void Scheduler::_storage_thread(void* arg)
         sched->delay_microseconds(10000);
     }
     while (true) {
-        sched->delay_microseconds(10000);
+        sched->delay_microseconds(1000);
 
         // process any pending storage writes
         hal.storage->_timer_tick();


### PR DESCRIPTION
The 100Hz update rate means there is a significant chance of an arming
failure after mission upload if you try to arm shortly after the
update. There is an arming check that all updated storage has been
written.

Each mission item is 15 bytes, so with a 1200 item mission we need to
write 18000 bytes to storage. At 100Hz, with 8 bytes per storage line,
that takes over 22 seconds.

For a 120 item mission we still needed to wait over 2 seconds to
be able to arm. This reduces that to 0.2s