### PR TITLE
AP_GPS Add configurable GPS difference and min sats for arming

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -440,13 +440,18 @@ bool AP_Arming::gps_checks(bool report)
             return false;
         }
 
+        if (gps.status() <= AP_GPS::GPS_OK_FIX_3D) {
+            check_failed(ARMING_CHECK_GPS, report, "Waiting for enhanced GPS fix");
+            return false;
+        }
+
         //GPS update rate acceptable
         if (!gps.is_healthy()) {
             check_failed(ARMING_CHECK_GPS, report, "GPS is not healthy");
             return false;
         }
 
-        // check GPSs are within 50m of each other and that blending is healthy
+        // check GPSs are within a configured max displacement of each other and that blending is healthy
         float distance_m;
         if (!gps.all_consistent(distance_m)) {
             check_failed(ARMING_CHECK_GPS, report, "GPS positions differ by %4.1fm",

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -298,6 +298,24 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DRV_OPTIONS", 22, AP_GPS, _driver_options, 0),
 
+    // @Param: MAX_POS_DIFF
+    // @DisplayName: Maximum Position Difference Between GPSs Accepted
+    // @Description: Sets the maximum allowed difference in meters allowed in GPS positions before takeoff.
+    // @Units: m
+    // @Range: 1.0 50.0
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("MAX_POS_DIFF", 23, AP_GPS, _max_pos_diff, 5.0f),
+
+    // @Param: NUM_SATS_ARM_MIN
+    // @DisplayName: Minimum Count Of Locked Satellites For Arming
+    // @Description: Sets the minimum count of locked satellites for arming.
+    // @Units: m
+    // @Range: 6.0 20.0
+    // @User: Advanced
+    // @RebootRequired: True
+    AP_GROUPINFO("NUM_SATS_ARM_MIN", 24, AP_GPS, _num_sats_arm_min, 16),
+
     AP_GROUPEND
 };
 
@@ -1257,8 +1275,8 @@ bool AP_GPS::all_consistent(float &distance) const
 
     // calculate distance
     distance = state[0].location.get_distance_NED(state[1].location).length();
-    // success if distance is within 50m
-    return (distance < 50);
+    // success if distance is within configured max position difference
+    return (distance < _max_pos_diff);
 }
 
 // pre-arm check of GPS blending.  True means healthy or that blending is not being used

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -314,7 +314,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Range: 6.0 20.0
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("NUM_SATS_ARM_MIN", 63, AP_GPS, _num_sats_arm_min, 16),
+    AP_GROUPINFO("NUM_SATS_MIN", 63, AP_GPS, _num_sats_arm_min, 16),
 
     AP_GROUPEND
 };

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -298,14 +298,14 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DRV_OPTIONS", 22, AP_GPS, _driver_options, 0),
 
-    // @Param: MAX_POS_DIFF
+    // @Param: POS_DIFF_MAX
     // @DisplayName: Maximum Position Difference Between GPSs Accepted
     // @Description: Sets the maximum allowed difference in meters allowed in GPS positions before takeoff.
     // @Units: m
     // @Range: 1.0 50.0
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("MAX_POS_DIFF", 62, AP_GPS, _max_pos_diff, 5.0f),
+    AP_GROUPINFO("POS_DIFF_MAX", 62, AP_GPS, _pos_diff_max, 5.0f),
 
     // @Param: NUM_SATS_ARM_MIN
     // @DisplayName: Minimum Count Of Locked Satellites For Arming
@@ -1276,7 +1276,7 @@ bool AP_GPS::all_consistent(float &distance) const
     // calculate distance
     distance = state[0].location.get_distance_NED(state[1].location).length();
     // success if distance is within configured max position difference
-    return (distance < _max_pos_diff);
+    return (distance < _pos_diff_max);
 }
 
 // pre-arm check of GPS blending.  True means healthy or that blending is not being used

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -305,7 +305,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Range: 1.0 50.0
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("MAX_POS_DIFF", 23, AP_GPS, _max_pos_diff, 5.0f),
+    AP_GROUPINFO("MAX_POS_DIFF", 62, AP_GPS, _max_pos_diff, 5.0f),
 
     // @Param: NUM_SATS_ARM_MIN
     // @DisplayName: Minimum Count Of Locked Satellites For Arming
@@ -314,7 +314,7 @@ const AP_Param::GroupInfo AP_GPS::var_info[] = {
     // @Range: 6.0 20.0
     // @User: Advanced
     // @RebootRequired: True
-    AP_GROUPINFO("NUM_SATS_ARM_MIN", 24, AP_GPS, _num_sats_arm_min, 16),
+    AP_GROUPINFO("NUM_SATS_ARM_MIN", 63, AP_GPS, _num_sats_arm_min, 16),
 
     AP_GROUPEND
 };

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -509,7 +509,7 @@ protected:
     AP_Int8 _blend_mask;
     AP_Float _blend_tc;
     AP_Int16 _driver_options;
-    AP_Float _max_pos_diff;
+    AP_Float _pos_diff_max;
     AP_Int8 _num_sats_arm_min;
 
     // GPS_DRV_OPTIONS bits

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -311,6 +311,11 @@ public:
         return num_sats(primary_instance);
     }
 
+    // minimum sats locked for arming
+    uint8_t num_sats_arm_min() const {
+        return _num_sats_arm_min;
+    }
+
     // GPS time of week in milliseconds
     uint32_t time_week_ms(uint8_t instance) const {
         return state[instance].time_week_ms;
@@ -504,6 +509,8 @@ protected:
     AP_Int8 _blend_mask;
     AP_Float _blend_tc;
     AP_Int16 _driver_options;
+    AP_Float _max_pos_diff;
+    AP_Int8 _num_sats_arm_min;
 
     // GPS_DRV_OPTIONS bits
     enum class DRV_OPTIONS {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -198,12 +198,12 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats
-    bool numSatsFail = (gps.num_sats() < 6) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsFail = (gps.num_sats() < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsFail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS numsats %u (needs 6)", gps.num_sats());
+                           "GPS numsats %u (needs %u)", gps.num_sats()), gps.num_sats_arm_min();
         gpsCheckStatus.bad_sats = true;
     } else {
         gpsCheckStatus.bad_sats = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -203,7 +203,7 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     // Report check result as a text string and bitmask
     if (numSatsFail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS numsats %u (needs %u)", gps.num_sats()), gps.num_sats_arm_min();
+                           "GPS numsats %u (needs %u)", gps.num_sats(), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
     } else {
         gpsCheckStatus.bad_sats = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -195,12 +195,12 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats
-    bool numSatsFail = (gps.num_sats() < 6) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsFail = (gps.num_sats() < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsFail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS numsats %u (needs 6)", gps.num_sats());
+                           "GPS numsats %u (needs %u)", gps.num_sats(), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
     } else {
         gpsCheckStatus.bad_sats = false;


### PR DESCRIPTION
Added configuration options:
- POS_DIFF_MAX
- NUM_SATS_MIN

Also require enhanced GPS fix for arming.