### PR TITLE
AP_GPS: fixed takeoff position check for blended GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1771,6 +1771,8 @@ void AP_GPS::calc_blended_state(void)
     }
     timing[GPS_BLENDED_INSTANCE].last_fix_time_ms = (uint32_t)temp_time_1;
     timing[GPS_BLENDED_INSTANCE].last_message_time_ms = (uint32_t)temp_time_2;
+
+    update_position_change(GPS_BLENDED_INSTANCE);
 }
 #endif // GPS_BLENDED_INSTANCE
 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -627,7 +627,7 @@ private:
       track change in position and height since arming. Used for
       pre-takeoff check
      */
-    Location _arm_loc[GPS_MAX_RECEIVERS];
+    Location _arm_loc[GPS_MAX_INSTANCES];
 
     // calculate the blend weight.  Returns true if blend could be calculated, false if not
     bool calc_blend_weights(void);


### PR DESCRIPTION
This fixes the check on changes in GPS position between arming and takeoff for using a blended GPS
