### PR TITLE
Pr fix snr build

### DIFF
--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -36,7 +36,7 @@ public:
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }
     uint16_t snr() const { return state.snr; }
-    void snr(uint16_t snr) { state.snr = snr; }
+    void snr(uint16_t snr_val) { state.snr = snr_val; }
     uint16_t voltage_mv() const { return state.voltage_mv; }
     int16_t max_distance_cm() const { return params.max_distance_cm; }
     int16_t min_distance_cm() const { return params.min_distance_cm; }


### PR DESCRIPTION
Some compilers complain about SNR overshadowing. Renamed the function parameter to appease those compilers.