### PR TITLE
Feature/apm 90/disallow arming on lane 2

### DIFF
--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -598,12 +598,15 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 
     const NavEKF2 &ekf2 = AP::ahrs_navekf().get_NavEKF2_const();
     const NavEKF3 &ekf3 = AP::ahrs_navekf().get_NavEKF3_const();
-
+    const int ekf_lane1 = 0;
+    const int ekf2_enabled = 2;
+    const int ekf3_enabled = 3;
+    
     // Do not arm if EKF lane 1 is not used as primary during arming, when using a certain EKF (EKF2 or EKF3).
-    if ((ahrs.get_ekf_type() == 2) && (ekf2.currentPrimaryLane() != 0)) {
+    if ((ahrs.get_ekf_type() == ekf2_enabled) && (ekf2.currentPrimaryLane() != ekf_lane1)) {
         check_failed(true, "EKF2 lane 1 not in use as primary");
         return false;
-    } else if ((ahrs.get_ekf_type() == 3) && (ekf3.currentPrimaryLane() != 0)) {
+    } else if ((ahrs.get_ekf_type() == ekf3_enabled) && (ekf3.currentPrimaryLane() != ekf_lane1)) {
         check_failed(true, "EKF3 lane 1 not in use as primary");
         return false;
     }

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -596,6 +596,21 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         return false;
     }
 
+    // Do not arm if EKF lane 1 is not used as primary during arming, when using EK2.
+    const NavEKF2 &ekf2 = AP::ahrs_navekf().get_NavEKF2_const();
+    if (ekf2.currentPrimary() != 0) {
+        check_failed(true, "EKF lane 1 not in use as primary");
+        return false;
+    }
+
+    // Do not arm if EKF lane 1 is not used as primary during arming, when using EK3
+    const NavEKF3 &ekf3 = AP::ahrs_navekf().get_NavEKF3_const();
+    if (ekf3.currentPrimary() != 0) {
+        check_failed(true, "EKF lane 1 not in use as primary");
+        return false;
+    }
+
+
 #ifndef ALLOW_ARM_NO_COMPASS
     // if external source of heading is available, we can skip compass health check
     if (!ahrs.is_ext_nav_used_for_yaw()) {

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -596,20 +596,17 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         return false;
     }
 
-    // Do not arm if EKF lane 1 is not used as primary during arming, when using EK2.
     const NavEKF2 &ekf2 = AP::ahrs_navekf().get_NavEKF2_const();
-    if (ekf2.currentPrimary() != 0) {
-        check_failed(true, "EKF lane 1 not in use as primary");
-        return false;
-    }
-
-    // Do not arm if EKF lane 1 is not used as primary during arming, when using EK3
     const NavEKF3 &ekf3 = AP::ahrs_navekf().get_NavEKF3_const();
-    if (ekf3.currentPrimary() != 0) {
-        check_failed(true, "EKF lane 1 not in use as primary");
+
+    // Do not arm if EKF lane 1 is not used as primary during arming, when using a certain EKF (EKF2 or EKF3).
+    if (ahrs.get_ekf_type() == 2 && ekf2.currentPrimaryLane() != 0) {
+        check_failed(true, "EKF2 lane 1 not in use as primary");
+        return false;
+    } else if (ahrs.get_ekf_type() == 3 && ekf3.currentPrimaryLane() != 0) {
+        check_failed(true, "EKF3 lane 1 not in use as primary");
         return false;
     }
-
 
 #ifndef ALLOW_ARM_NO_COMPASS
     // if external source of heading is available, we can skip compass health check

--- a/ArduCopter/AP_Arming.cpp
+++ b/ArduCopter/AP_Arming.cpp
@@ -600,10 +600,10 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
     const NavEKF3 &ekf3 = AP::ahrs_navekf().get_NavEKF3_const();
 
     // Do not arm if EKF lane 1 is not used as primary during arming, when using a certain EKF (EKF2 or EKF3).
-    if (ahrs.get_ekf_type() == 2 && ekf2.currentPrimaryLane() != 0) {
+    if ((ahrs.get_ekf_type() == 2) && (ekf2.currentPrimaryLane() != 0)) {
         check_failed(true, "EKF2 lane 1 not in use as primary");
         return false;
-    } else if (ahrs.get_ekf_type() == 3 && ekf3.currentPrimaryLane() != 0) {
+    } else if ((ahrs.get_ekf_type() == 3) && (ekf3.currentPrimaryLane() != 0)) {
         check_failed(true, "EKF3 lane 1 not in use as primary");
         return false;
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -52,7 +52,7 @@ public:
     }
 
     // Gets the lane number which is used as primary
-    uint8_t currentPrimary(void) const {
+    uint8_t currentPrimaryLane(void) const {
         return primary;
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -51,6 +51,11 @@ public:
         return num_cores;
     }
 
+    // Gets the lane number which is used as primary
+    uint8_t currentPrimary(void) const {
+        return primary;
+    }
+
     // Initialise the filter
     bool InitialiseFilter(void);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -48,6 +48,11 @@ public:
         return num_cores;
     }
 
+    // Gets the lane number which is used as primary
+    uint8_t currentPrimary(void) const {
+        return primary;
+    }
+
     // Initialise the filter
     bool InitialiseFilter(void);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -49,7 +49,7 @@ public:
     }
 
     // Gets the lane number which is used as primary
-    uint8_t currentPrimary(void) const {
+    uint8_t currentPrimaryLane(void) const {
         return primary;
     }
 


### PR DESCRIPTION
https://matternet.atlassian.net/browse/APM-90
Patch to not allow the aircraft to arm if the aircraft is using an EKF lane other than EKF Lane 1.