### PR TITLE
AP_ARMING AP_COMPASS limit mag limits furter

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -49,8 +49,8 @@
 #include <AP_Logger/AP_Logger.h>
 
 #define AP_ARMING_COMPASS_MAGFIELD_EXPECTED 530
-#define AP_ARMING_COMPASS_MAGFIELD_MIN  185     // 0.35 * 530 milligauss
-#define AP_ARMING_COMPASS_MAGFIELD_MAX  875     // 1.65 * 530 milligauss
+#define AP_ARMING_COMPASS_MAGFIELD_MIN  200     // 0.35 * 530 milligauss, limited further for mttr ops
+#define AP_ARMING_COMPASS_MAGFIELD_MAX  700     // 1.65 * 530 milligauss, limited further for mttr ops
 #define AP_ARMING_BOARD_VOLTAGE_MAX     5.8f
 #define AP_ARMING_ACCEL_ERROR_THRESHOLD 0.75f
 #define AP_ARMING_AHRS_GPS_ERROR_MAX    10      // accept up to 10m difference between AHRS and GPS

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -49,8 +49,8 @@
 #include <AP_Logger/AP_Logger.h>
 
 #define AP_ARMING_COMPASS_MAGFIELD_EXPECTED 530
-#define AP_ARMING_COMPASS_MAGFIELD_MIN  200     // 0.35 * 530 milligauss, limited further for mttr ops
-#define AP_ARMING_COMPASS_MAGFIELD_MAX  700     // 1.65 * 530 milligauss, limited further for mttr ops
+#define AP_ARMING_COMPASS_MAGFIELD_MIN  200     // 250 milligauss min closer to the equator, give 50 mG buffer
+#define AP_ARMING_COMPASS_MAGFIELD_MAX  700     // 650 milligauss max closer to poles, give 50 mG buffer
 #define AP_ARMING_BOARD_VOLTAGE_MAX     5.8f
 #define AP_ARMING_ACCEL_ERROR_THRESHOLD 0.75f
 #define AP_ARMING_AHRS_GPS_ERROR_MAX    10      // accept up to 10m difference between AHRS and GPS

--- a/libraries/AP_Compass/AP_Compass.h
+++ b/libraries/AP_Compass/AP_Compass.h
@@ -38,9 +38,9 @@
 
 // define default compass calibration fitness and consistency checks
 #define AP_COMPASS_CALIBRATION_FITNESS_DEFAULT 16.0f
-#define AP_COMPASS_MAX_XYZ_ANG_DIFF radians(90.0f)
-#define AP_COMPASS_MAX_XY_ANG_DIFF radians(60.0f)
-#define AP_COMPASS_MAX_XY_LENGTH_DIFF 200.0f
+#define AP_COMPASS_MAX_XYZ_ANG_DIFF radians(30.0f)
+#define AP_COMPASS_MAX_XY_ANG_DIFF radians(20.0f)
+#define AP_COMPASS_MAX_XY_LENGTH_DIFF 100.0f
 
 /**
    maximum number of compass instances available on this platform. If more


### PR DESCRIPTION
Tighten the hardcoded mag limits to narrow the mag deviation allowed in prearm checks for the following:
-AP_ARMING_COMPASS_MAGFIELD_MIN
- AP_ARMING_COMPASS_MAGFIELD_MAX
- AP_COMPASS_MAX_XYZ_ANG_DIFF
- AP_COMPASS_MAX_XY_ANG_DIFF
- AP_COMPASS_MAX_XY_LENGTH_DIFF