### PR TITLE
Set BRAKE_MODE_DECEL_RATE to match WPNAV_ACCEL

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -602,7 +602,7 @@
  # define BRAKE_MODE_SPEED_Z     250 // z-axis speed in cm/s in Brake Mode
 #endif
 #ifndef BRAKE_MODE_DECEL_RATE
- # define BRAKE_MODE_DECEL_RATE  750 // acceleration rate in cm/s/s in Brake Mode
+ # define BRAKE_MODE_DECEL_RATE  150 // acceleration rate in cm/s/s in Brake Mode
 #endif
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Set BRAKE_MODE_DECEL_RATE to match WPNAV_ACCEL to reduce xtrack error observed while navigating corners following a hold and resolve "sling-shot" behavior when traveling at high groundspeed and commanding brake.