### PR TITLE
Support mission pause via DO_CHANGE_SPEED

### DIFF
--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -396,6 +396,13 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         reached_leash_limit = true;
     }
 
+    /*
+      if mission is paused then stop advancing leash
+     */
+    if (_mission_paused) {
+        reached_leash_limit = true;
+    }
+
     // get current velocity
     const Vector3f &curr_vel = _inav.get_velocity();
     // get speed along track
@@ -1128,4 +1135,10 @@ float AC_WPNav::commanded_alt_target_offset(float dt)
     }
 
     return _commanded_alt_offset_cm;
+}
+
+/// set mission pause state
+void AC_WPNav::set_pause(bool paused)
+{
+    _mission_paused = paused;
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -75,6 +75,12 @@ public:
     void set_speed_up(float speed_up_cms);
     void set_speed_down(float speed_down_cms);
 
+    /// set mission pause state
+    void set_pause(bool paused);
+
+    /// get mission pause state
+    bool get_pause(void) const { return _mission_paused; }
+
     /// get default target horizontal velocity during wp navigation
     float get_default_speed_xy() const { return _wp_speed_cms; }
 
@@ -334,4 +340,5 @@ protected:
     float _commanded_alt_cm;
     float _commanded_alt_offset_cm;
     uint32_t _commanded_alt_last_update_ms;
+    bool _mission_paused;
 };


### PR DESCRIPTION
Using DO_CHANGE_SPEED with the speed_type of 0 or 1 now accepts a speed of zero to mean "pause mission". A speed > 0 will unpause mission.
This only pauses the forward part of the mission, so you can combine this with a changealt command to climb/descend while paused.
To test you can use the "setspeed" command in MAVProxy with a speed in m/s
