### PR TITLE
APM-123 Pr report min sat prearm gps2

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -208,11 +208,13 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                            "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
-    } else if(numSatsGPS2Fail) {
+    }
+    if (numSatsGPS2Fail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                            "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
-    } else {
+    } 
+    if (!numSatsGPS1Fail && !numSatsGPS2Fail) {
         gpsCheckStatus.bad_sats = false;
     }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -205,11 +205,13 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                            "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
-    } else if(numSatsGPS2Fail) {
+    }
+    if (numSatsGPS2Fail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                            "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
-    } else {
+    } 
+    if (!numSatsGPS1Fail && !numSatsGPS2Fail) {
         gpsCheckStatus.bad_sats = false;
     }
 


### PR DESCRIPTION
Currently the message for the num sats GPS2 failed prearm check is reported only if GPS1 passes.

This removes the dependency between GPS1 and GPS2 sat count prearm messages.