### PR TITLE
APM-121 - Prearm check for GPS2 min allowed status

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "modules/uavcan"]
 	path = modules/uavcan
-	url = git://github.com/ArduPilot/uavcan.git
+	url = https://github.com/ArduPilot/uavcan.git
 [submodule "modules/waf"]
 	path = modules/waf
-	url = git://github.com/ArduPilot/waf.git
+	url = https://github.com/ArduPilot/waf.git
 [submodule "modules/gbenchmark"]
 	path = modules/gbenchmark
-	url = git://github.com/google/benchmark.git
+	url = https://github.com/google/benchmark.git
 [submodule "modules/mavlink"]
 	path = modules/mavlink
-	url = git://github.com/ArduPilot/mavlink
+	url = https://github.com/ArduPilot/mavlink
 [submodule "gtest"]
 	path = modules/gtest
-	url = git://github.com/ArduPilot/googletest
+	url = https://github.com/ArduPilot/googletest
 [submodule "modules/ChibiOS"]
 	path = modules/ChibiOS
-	url = git://github.com/ArduPilot/ChibiOS.git
+	url = https://github.com/ArduPilot/ChibiOS.git
 [submodule "modules/libcanard"]
 	path = modules/libcanard
-	url = git://github.com/ArduPilot/libcanard.git
+	url = https://github.com/ArduPilot/libcanard.git

--- a/Tools/gittools/submodule-sync.sh
+++ b/Tools/gittools/submodule-sync.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# this copes with moving origin remote to a new git organisation
+# we run it 3 times due to the poor handling of recursion
+git submodule update --recursive --force --init
+git submodule sync --recursive
+
+git submodule update --recursive --force --init
+git submodule sync --recursive
+
+git submodule update --recursive --force --init
+git submodule sync --recursive

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -433,6 +433,9 @@ bool AP_Arming::gps_checks(bool report)
     const AP_GPS &gps = AP::gps();
     if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS)) {
 
+        bool gps1_status_fail = false;
+        bool gps2_status_fail = false;
+
         //GPS OK?
         if (!AP::ahrs().home_is_set() ||
             gps.status() < AP_GPS::GPS_OK_FIX_3D) {
@@ -440,8 +443,17 @@ bool AP_Arming::gps_checks(bool report)
             return false;
         }
 
-        if (gps.status() < gps.status_arm_min()) {
-            check_failed(ARMING_CHECK_GPS, report, "Waiting for enhanced GPS fix");
+        if (gps.status(0) < gps.status_arm_min()) {
+            check_failed(ARMING_CHECK_GPS, report, "GPS 1 Fix %u (needs %u)", gps.status(0), gps.status_arm_min());
+            gps1_status_fail = true;
+        }
+
+        if (gps.status(1) < gps.status_arm_min()) {
+            check_failed(ARMING_CHECK_GPS, report, "GPS 2 Fix %u (needs %u)", gps.status(1), gps.status_arm_min());
+            gps2_status_fail = true;
+        }
+
+        if (gps1_status_fail || gps2_status_fail) {
             return false;
         }
 


### PR DESCRIPTION
Added Prearm check for minimum allowed fix type (status) for GPS2. Previously this check was only applicable for the primary GPS.
https://matternet.atlassian.net/browse/APM-121