### PR TITLE
AP_Compass: added register checking for AK09916 mode

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK09916.h
+++ b/libraries/AP_Compass/AP_Compass_AK09916.h
@@ -77,7 +77,6 @@ private:
 
     AP_AK09916_BusDriver *_bus;
 
-    float _magnetometer_ASA[3] {0, 0, 0};
     bool _force_external;
     uint8_t _compass_instance;
     bool _initialized;
@@ -93,7 +92,7 @@ public:
 
     virtual bool block_read(uint8_t reg, uint8_t *buf, uint32_t size) = 0;
     virtual bool register_read(uint8_t reg, uint8_t *val) = 0;
-    virtual bool register_write(uint8_t reg, uint8_t val) = 0;
+    virtual bool register_write(uint8_t reg, uint8_t val, bool checked=false) = 0;
 
     virtual AP_HAL::Semaphore  *get_semaphore() = 0;
 
@@ -106,6 +105,14 @@ public:
 
     // return 24 bit bus identifier
     virtual uint32_t get_bus_id(void) const = 0;
+
+    /**
+     setup for register value checking. Frequency is how often to
+     check registers. If set to 10 then every 10th call to
+     check_next_register will check a register
+     */
+    virtual void setup_checked_registers(uint8_t num_regs) {}
+    virtual void check_next_register(void) {}
 };
 
 class AP_AK09916_BusDriver_HALDevice: public AP_AK09916_BusDriver
@@ -115,7 +122,7 @@ public:
 
     virtual bool block_read(uint8_t reg, uint8_t *buf, uint32_t size) override;
     virtual bool register_read(uint8_t reg, uint8_t *val) override;
-    virtual bool register_write(uint8_t reg, uint8_t val) override;
+    virtual bool register_write(uint8_t reg, uint8_t val, bool checked) override;
 
     virtual AP_HAL::Semaphore  *get_semaphore() override;
     AP_HAL::Device::PeriodicHandle register_periodic_callback(uint32_t period_usec, AP_HAL::Device::PeriodicCb) override;
@@ -128,6 +135,18 @@ public:
     // return 24 bit bus identifier
     uint32_t get_bus_id(void) const override {
         return _dev->get_bus_id();
+    }
+
+    /**
+     setup for register value checking. Frequency is how often to
+     check registers. If set to 10 then every 10th call to
+     check_next_register will check a register
+     */
+    void setup_checked_registers(uint8_t num_regs) override {
+        _dev->setup_checked_registers(num_regs);
+    }
+    void check_next_register(void) override {
+        _dev->check_next_register();
     }
     
 private:
@@ -143,7 +162,7 @@ public:
 
     bool block_read(uint8_t reg, uint8_t *buf, uint32_t size) override;
     bool register_read(uint8_t reg, uint8_t *val) override;
-    bool register_write(uint8_t reg, uint8_t val) override;
+    bool register_write(uint8_t reg, uint8_t val, bool checked) override;
 
     AP_HAL::Device::PeriodicHandle register_periodic_callback(uint32_t period_usec, AP_HAL::Device::PeriodicCb) override;
     


### PR DESCRIPTION
this allows AK09916 on I2C to recover from a power outage in flight
This is an alternative to #213 that uses the checked register API
