### PR TITLE
Manufacturing Test: Allow parachute release when landed

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -264,6 +264,7 @@ void Copter::parachute_manual_release()
         return;
     }
 
+#if 0  // Matternet manufacturing test: Allow parachute release when landed
     // do not release if vehicle is landed
     // do not release if we are landed or below the minimum altitude above home
     if (ap.land_complete) {
@@ -272,6 +273,7 @@ void Copter::parachute_manual_release()
         AP::logger().Write_Error(LogErrorSubsystem::PARACHUTES, LogErrorCode::PARACHUTE_LANDED);
         return;
     }
+#endif
 
     // do not release if we are landed or below the minimum altitude above home
 #if 0


### PR DESCRIPTION
This disables the check for a landed aircraft so the parachute can be deployed with the MAV_CMD_DO_PARACHUTE command at any time.