### PR TITLE
Bugfix/apm 144 gps2 low sats alert

### DIFF
--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -486,10 +486,6 @@ public:
         return instance>=GPS_MAX_RECEIVERS? GPS_Type::GPS_TYPE_NONE : GPS_Type(_type[instance].get());
     }
 
-    bool gps_instance_exists(uint8_t instance) const {
-        return get_type(instance) =! GPS_Type::GPS_TYPE_NONE;
-    }
-
     // get change in position and altitude since arming
     bool get_pre_arm_pos_change(uint8_t instance, float &pos_change, float &alt_change) const;
     bool get_pre_arm_pos_change(float &pos_change, float &alt_change) const {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -486,6 +486,10 @@ public:
         return instance>=GPS_MAX_RECEIVERS? GPS_Type::GPS_TYPE_NONE : GPS_Type(_type[instance].get());
     }
 
+    bool gps_instance_exists(uint8_t instance) const {
+        return get_type(instance) =! GPS_Type::GPS_TYPE_NONE;
+    }
+
     // get change in position and altitude since arming
     bool get_pre_arm_pos_change(uint8_t instance, float &pos_change, float &alt_change) const;
     bool get_pre_arm_pos_change(float &pos_change, float &alt_change) const {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -198,24 +198,20 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats for GPS1
-    bool numSatsGPS1Fail = (gps.gps_instance_exists(0)) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS1Fail = (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
-    bool numSatsGPS2Fail = (gps.gps_instance_exists(1)) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool gps2Present = gps.num_sensors() > 1;
+    bool numSatsGPS2Fail = (gps2Present) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {
-        if (gps.gps_instance_exists(0)) {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
-        }
-        else {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 1 not present for sat check");
-        }
+        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                       "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
     }
     if (numSatsGPS2Fail) {
-        if (gps.gps_instance_exists(1)) {
+        if (gps2Present) {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                                "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
         }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -199,6 +199,8 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
 
     // fail if not enough sats for GPS1
     bool numSatsGPS1Fail = (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                   "GPS 0 has %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
     bool gps2Present = gps.num_sensors() > 1;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -199,8 +199,6 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
 
     // fail if not enough sats for GPS1
     bool numSatsGPS1Fail = (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
-    hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                   "GPS 0 has %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
     bool gps2Present = gps.num_sensors() > 1;
@@ -215,7 +213,8 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     if (numSatsGPS2Fail) {
         if (gps2Present) {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                               "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+                               numSatsGPS1Fail ? "GPS 1 numsats %u, GPS 2 numsats %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min()
+                               : "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
         }
         else {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -198,10 +198,10 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats for GPS1
-    bool numSatsGPS1Fail = (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS1Fail = (gps.get_type(0) =! GPS_Type::GPS_TYPE_NONE) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
-    bool numSatsGPS2Fail = (gps.get_type(1) == 1) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS2Fail = (gps.get_type(1) =! GPS_Type::GPS_TYPE_NONE) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -212,9 +212,14 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     }
     if (numSatsGPS2Fail) {
         if (gps2Present) {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                               numSatsGPS1Fail ? ("GPS 1 numsats %u GPS 2 numsats %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min())
-                               : ("GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min()));
+            if (numSatsGPS1Fail) {
+                hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                                "GPS 1 numsats %u GPS 2 numsats %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min());
+            }
+            else {
+                hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                                "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+            }
         }
         else {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -213,8 +213,8 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     if (numSatsGPS2Fail) {
         if (gps2Present) {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                               numSatsGPS1Fail ? "GPS 1 numsats %u, GPS 2 numsats %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min()
-                               : "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+                               numSatsGPS1Fail ? ("GPS 1 numsats %u GPS 2 numsats %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min())
+                               : ("GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min()));
         }
         else {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -222,7 +222,7 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
             }
         }
         else {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS2 not present for sat check");
         }
         gpsCheckStatus.bad_sats = true;
     } 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -198,20 +198,30 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats for GPS1
-    bool numSatsGPS1Fail = (gps.get_type(0) =! GPS_Type::GPS_TYPE_NONE) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS1Fail = (gps.gps_instance_exists(0)) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
-    bool numSatsGPS2Fail = (gps.get_type(1) =! GPS_Type::GPS_TYPE_NONE) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS2Fail = (gps.gps_instance_exists(1)) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {
-        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+        if (gps.gps_instance_exists(0)) {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                            "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
+        }
+        else {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 1 not present for sat check");
+        }
         gpsCheckStatus.bad_sats = true;
     }
     if (numSatsGPS2Fail) {
-        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+        if (gps.gps_instance_exists(1)) {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                               "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+        }
+        else {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");
+        }
         gpsCheckStatus.bad_sats = true;
     } 
     if (!numSatsGPS1Fail && !numSatsGPS2Fail) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -207,18 +207,18 @@ void NavEKF2_core::calcGpsGoodToAlign(void)
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                       "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
+                       "GPS1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
     }
     if (numSatsGPS2Fail) {
         if (gps2Present) {
             if (numSatsGPS1Fail) {
                 hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                                "GPS 1 numsats %u GPS 2 numsats %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min());
+                                "GPS1 numsats %u GPS2 %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min());
             }
             else {
                 hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                                "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+                                "GPS2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
             }
         }
         else {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -204,13 +204,19 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {
         hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                       "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
+                       "GPS1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
     }
     if (numSatsGPS2Fail) {
         if (gps2Present) {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                               "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+            if (numSatsGPS1Fail) {
+                hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                                "GPS1 numsats %u GPS2 %u (need %u)", gps.num_sats(0), gps.num_sats(1), gps.num_sats_arm_min());
+            }
+            else {
+                hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                                "GPS2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+            }
         }
         else {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -195,24 +195,20 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats for GPS1
-    bool numSatsGPS1Fail = (gps.gps_instance_exists(0)) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS1Fail = (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
-    bool numSatsGPS2Fail = (gps.gps_instance_exists(1)) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool gps2Present = gps.num_sensors() > 1;
+    bool numSatsGPS2Fail = (gps2Present) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {
-        if (gps.gps_instance_exists(0)) {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
-        }
-        else {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 1 not present for sat check");
-        }
+        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                       "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
         gpsCheckStatus.bad_sats = true;
     }
     if (numSatsGPS2Fail) {
-        if (gps.gps_instance_exists(1)) {
+        if (gps2Present) {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                                "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -195,20 +195,32 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats for GPS1
-    bool numSatsGPS1Fail = (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool gps1InstanceExists = gps.get_type(0) != GPS_Type::GPS_TYPE_NONE;
+    bool numSatsGPS1Fail = (gps1InstanceExists) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
-    bool numSatsGPS2Fail = (gps.get_type(1) == 1) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool gps2InstanceExists = gps.get_type(1) != GPS_Type::GPS_TYPE_NONE;
+    bool numSatsGPS2Fail = (gps2InstanceExists) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {
-        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+        if (gps1InstanceExists) {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                            "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
+        }
+        else {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 1 not present for sat check");
+        }
         gpsCheckStatus.bad_sats = true;
     }
     if (numSatsGPS2Fail) {
-        hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
-                           "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+        if (gps2InstanceExists) {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
+                               "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
+        }
+        else {
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");
+        }
         gpsCheckStatus.bad_sats = true;
     } 
     if (!numSatsGPS1Fail && !numSatsGPS2Fail) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -219,7 +219,7 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
             }
         }
         else {
-            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS 2 not present for sat check");
+            hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string), "GPS2 not present for sat check");
         }
         gpsCheckStatus.bad_sats = true;
     } 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_VehicleStatus.cpp
@@ -195,16 +195,14 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
     }
 
     // fail if not enough sats for GPS1
-    bool gps1InstanceExists = gps.get_type(0) != GPS_Type::GPS_TYPE_NONE;
-    bool numSatsGPS1Fail = (gps1InstanceExists) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS1Fail = (gps.gps_instance_exists(0)) && (gps.num_sats(0) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // fail if GPS2 is enabled and not enough sats for secondary GPS2
-    bool gps2InstanceExists = gps.get_type(1) != GPS_Type::GPS_TYPE_NONE;
-    bool numSatsGPS2Fail = (gps2InstanceExists) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
+    bool numSatsGPS2Fail = (gps.gps_instance_exists(1)) && (gps.num_sats(1) < gps.num_sats_arm_min()) && (frontend->_gpsCheck & MASK_GPS_NSATS);
 
     // Report check result as a text string and bitmask
     if (numSatsGPS1Fail) {
-        if (gps1InstanceExists) {
+        if (gps.gps_instance_exists(0)) {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                            "GPS 1 numsats %u (needs %u)", gps.num_sats(0), gps.num_sats_arm_min());
         }
@@ -214,7 +212,7 @@ void NavEKF3_core::calcGpsGoodToAlign(void)
         gpsCheckStatus.bad_sats = true;
     }
     if (numSatsGPS2Fail) {
-        if (gps2InstanceExists) {
+        if (gps.gps_instance_exists(1)) {
             hal.util->snprintf(prearm_fail_string, sizeof(prearm_fail_string),
                                "GPS 2 numsats %u (needs %u)", gps.num_sats(1), gps.num_sats_arm_min());
         }


### PR DESCRIPTION
Fixed sats min alerts to report both GPS sources if both are below threshold. The last populated prearm message is reported so cannot write the messages independently. 