### PR TITLE
AIR-952: Remove debug message for FTS version

### DIFF
--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -289,8 +289,6 @@ void AP_Parachute::mttr_fts_update()
                 memset(_mttr_fts_version, 0, sizeof(_mttr_fts_version));
                 memcpy(_mttr_fts_version, msg->git_hash, sizeof(msg->git_hash));
                 AP::logger().Write("FTSV", "TimeUS,Hash", "QN", AP_HAL::micros64(), _mttr_fts_version);
-                // Manufacturing test debug message
-                gcs().send_text(MAV_SEVERITY_INFO, "FTS version: %s", _mttr_fts_version);
             } else if (msg_id == FTS_MSGID_STATUS2) {
                 struct fts_msg_status2_s* msg = (struct fts_msg_status2_s*)msg_buf;
 


### PR DESCRIPTION
Mainline code already has support for fetching FTS version.