### PR TITLE
APM-147 Add: send rangefinder versions over mavlink

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -173,7 +173,7 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
   Populate a buffer with the version string found upon device init.
  */
 void AP_RangeFinder_LightWareI2C::get_version(char *buffer, uint8_t length) const {
-    if (!buffer) {
+    if (!buffer || length == 0) {
         return;
     }
     snprintf(buffer, length, "%s%s", RANGEFINDER_LIDAR_I2C_VERSION_PREFIX, version_);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -80,7 +80,7 @@ AP_RangeFinder_LightWareI2C::AP_RangeFinder_LightWareI2C(RangeFinder::RangeFinde
         AP_RangeFinder_Params &_params,
         AP_HAL::OwnPtr<AP_HAL::I2CDevice> dev)
     : AP_RangeFinder_Backend(_state, _params)
-    , version_("")
+    , version_("UNKNOWN")
     , _dev(std::move(dev))
     , read_errors_(0)
     {}
@@ -169,12 +169,12 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
     return memcmp(rx_bytes, expected_reply, expected_reply_len) == 0;
 }
 
-const char *AP_RangeFinder_LightWareI2C::get_version() const {
-    char *full_version = (char*) malloc((LIDAR_VERSION_STRING_SIZE + strlen(RANGEFINDER_LIDAR_I2C_VERSION_PREFIX))
-                                 * sizeof(char) + 1);
-    strcat(full_version, RANGEFINDER_LIDAR_I2C_VERSION_PREFIX);
-    strcat(full_version, version_);
-    return full_version;
+/*
+  Populate a buffer with the version string found upon device init.
+ */
+void AP_RangeFinder_LightWareI2C::get_version(char *buffer) const {
+    strcpy(buffer, RANGEFINDER_LIDAR_I2C_VERSION_PREFIX);
+    strcat(buffer, version_);
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -173,6 +173,9 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
   Populate a buffer with the version string found upon device init.
  */
 void AP_RangeFinder_LightWareI2C::get_version(char *buffer, uint8_t length) const {
+    if (!buffer) {
+        return;
+    }
     snprintf(buffer, length, "%s%s", RANGEFINDER_LIDAR_I2C_VERSION_PREFIX, version_);
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -172,9 +172,8 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
 /*
   Populate a buffer with the version string found upon device init.
  */
-void AP_RangeFinder_LightWareI2C::get_version(char *buffer) const {
-    strcpy(buffer, RANGEFINDER_LIDAR_I2C_VERSION_PREFIX);
-    strcat(buffer, version_);
+void AP_RangeFinder_LightWareI2C::get_version(char *buffer, uint8_t length) const {
+    snprintf(buffer, length, "%s%s", RANGEFINDER_LIDAR_I2C_VERSION_PREFIX, version_);
 }
 
 /*
@@ -227,6 +226,8 @@ bool AP_RangeFinder_LightWareI2C::init()
         // This call may be deprecated in the future.
         return true;
     }
+    // Reset lidar to be unknown and update last re-init time.
+    strcpy(version_, "UNKNOWN");
     last_init_time_ms = AP_HAL::millis();
     return false;
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -3,7 +3,6 @@
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
 #include <AP_HAL/I2CDevice.h>
-#include <string.h>
 
 #define NUM_SF20_DATA_STREAMS 1
 #define LIDAR_VERSION_STRING_SIZE 15
@@ -20,7 +19,7 @@ public:
     // update state
     void update(void) override;
 
-    const char *get_version() const override;
+    void get_version(char *buffer) const override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -3,8 +3,10 @@
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
 #include <AP_HAL/I2CDevice.h>
+#include <string.h>
 
 #define NUM_SF20_DATA_STREAMS 1
+#define LIDAR_VERSION_STRING_SIZE 15
 
 class AP_RangeFinder_LightWareI2C : public AP_RangeFinder_Backend
 {
@@ -17,6 +19,8 @@ public:
 
     // update state
     void update(void) override;
+
+    const char *get_version() const override;
 
 protected:
 
@@ -58,5 +62,6 @@ private:
     void data_log(uint16_t *val);
     AP_HAL::OwnPtr<AP_HAL::I2CDevice> _dev;
 
+    char version_[LIDAR_VERSION_STRING_SIZE];
     uint32_t read_errors_;
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -19,7 +19,7 @@ public:
     // update state
     void update(void) override;
 
-    void get_version(char *buffer) const override;
+    void get_version(char *buffer, uint8_t length) const override;
 
 protected:
 

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -33,6 +33,9 @@
 #define RANGEFINDER_PREARM_REQUIRED_CHANGE_CM   50
 #endif
 
+// Prefixes for different types of rangefinders. If more require support define them here.
+#define RANGEFINDER_LIDAR_I2C_VERSION_PREFIX "I2C Lidar "
+
 class AP_RangeFinder_Backend;
 
 class RangeFinder
@@ -154,7 +157,7 @@ public:
 
     // indicate which bit in LOG_BITMASK indicates RFND should be logged
     void set_rfnd_bit(uint32_t log_rfnd_bit) { _log_rfnd_bit = log_rfnd_bit; }
-    
+
     uint16_t snr(enum Rotation orientation) const;
 
     /*

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -16,6 +16,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
+#include <string.h>
 #include "RangeFinder.h"
 
 class AP_RangeFinder_Backend
@@ -33,7 +34,7 @@ public:
 
     virtual void handle_msg(const mavlink_message_t &msg) { return; }
 
-    virtual const char *get_version() const { return "";}
+    virtual void get_version(char *buffer) const { strcpy(buffer,""); }
 
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -34,7 +34,7 @@ public:
 
     virtual void handle_msg(const mavlink_message_t &msg) { return; }
 
-    virtual void get_version(char *buffer) const { strcpy(buffer,""); }
+    virtual void get_version(char *buffer, uint8_t length) const { strncpy(buffer, "", length); }
 
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -17,6 +17,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <string.h>
+#include <stdio.h>
 #include "RangeFinder.h"
 
 class AP_RangeFinder_Backend

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -34,7 +34,12 @@ public:
 
     virtual void handle_msg(const mavlink_message_t &msg) { return; }
 
-    virtual void get_version(char *buffer, uint8_t length) const { strncpy(buffer, "", length); }
+    virtual void get_version(char *buffer, uint8_t length) const {
+      if (!buffer) {
+        return;
+      }
+      strncpy(buffer, "", length);
+    }
 
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -33,6 +33,8 @@ public:
 
     virtual void handle_msg(const mavlink_message_t &msg) { return; }
 
+    virtual const char *get_version() const { return "";}
+
     enum Rotation orientation() const { return (Rotation)params.orientation.get(); }
     uint16_t distance_cm() const { return state.distance_cm; }
     uint16_t snr() const { return state.snr; }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -221,7 +221,7 @@ public:
     bool locked() const;
 
     // return a bitmap of active channels. Used by libraries to loop
-    // over active channels to send to all active channels    
+    // over active channels to send to all active channels
     static uint8_t active_channel_mask(void) { return mavlink_active; }
 
     // return a bitmap of streaming channels
@@ -238,7 +238,7 @@ public:
     static bool is_private(mavlink_channel_t _chan) {
         return (mavlink_private & (1U<<(unsigned)_chan)) != 0;
     }
-    
+
     // return true if channel is private
     bool is_private(void) const { return is_private(chan); }
 
@@ -252,7 +252,7 @@ public:
       allow forwarding of packets / heartbeats to be blocked as required by some components to reduce traffic
     */
     static void disable_channel_routing(mavlink_channel_t chan) { routing.no_route_mask |= (1U<<(chan-MAVLINK_COMM_0)); }
-    
+
     /*
       search for a component in the routing table with given mav_type and retrieve it's sysid, compid and channel
       returns if a matching component is found
@@ -371,6 +371,7 @@ protected:
     MAV_RESULT handle_command_request_autopilot_capabilities(const mavlink_command_long_t &packet);
 
     void send_matternet_FTS_version(void) const;
+    void send_rangefinder_versions(void) const;
 
     virtual void send_banner();
 
@@ -583,7 +584,7 @@ private:
 
     // time when we missed sending a parameter for GCS
     static uint32_t reserve_param_space_start_ms;
-    
+
     // bitmask of what mavlink channels are active
     static uint8_t mavlink_active;
 
@@ -603,7 +604,7 @@ private:
     };
 
     struct pending_param_reply {
-        mavlink_channel_t chan;        
+        mavlink_channel_t chan;
         float value;
         enum ap_var_type p_type;
         int16_t param_index;
@@ -662,7 +663,7 @@ private:
 
     struct pending_ftp {
         uint32_t offset;
-        mavlink_channel_t chan;        
+        mavlink_channel_t chan;
         uint16_t seq_number;
         FTP_OP opcode;
         FTP_OP req_opcode;
@@ -735,11 +736,11 @@ private:
       since boot in milliseconds
      */
     uint32_t correct_offboard_timestamp_usec_to_ms(uint64_t offboard_usec, uint16_t payload_size);
-    
+
     mavlink_signing_t signing;
     static mavlink_signing_streams_t signing_streams;
     static uint32_t last_signing_save_ms;
-    
+
     static StorageAccess _signing_storage;
     static bool signing_key_save(const struct SigningKey &key);
     static bool signing_key_load(struct SigningKey &key);
@@ -756,7 +757,7 @@ private:
     } alternative;
 
     JitterCorrection lag_correction;
-    
+
     // we cache the current location and send it even if the AHRS has
     // no idea where we are:
     struct Location global_position_current_loc;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -121,7 +121,7 @@ bool GCS_MAVLINK::init(uint8_t instance)
     }
     // since tcdrain() and TCSADRAIN may not be implemented...
     hal.scheduler->delay(1);
-    
+
     _port->set_flow_control(old_flow_control);
 
     // now change back to desired baudrate
@@ -141,7 +141,7 @@ bool GCS_MAVLINK::init(uint8_t instance)
     if (status == nullptr) {
         return false;
     }
-    
+
     if (mavlink_protocol == AP_SerialManager::SerialProtocol_MAVLink2) {
         // load signing key
         load_signing_key();
@@ -1325,7 +1325,7 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
     {
         const uint8_t c = (uint8_t)_port->read();
         const uint32_t protocol_timeout = 4000;
-        
+
         if (alternative.handler &&
             now_ms - alternative.last_mavlink_ms > protocol_timeout) {
             /*
@@ -1337,7 +1337,7 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
                 alternative.last_alternate_ms = now_ms;
                 gcs_alternative_active[chan] = true;
             }
-            
+
             /*
               we may also try parsing as MAVLink if we haven't had a
               successful parse on the alternative protocol for 4s
@@ -1462,7 +1462,7 @@ GCS_MAVLINK::update_receive(uint32_t max_time_us)
     }
 #endif
 
-    hal.util->perf_end(_perf_update);    
+    hal.util->perf_end(_perf_update);
 }
 
 /*
@@ -1538,7 +1538,7 @@ void GCS_MAVLINK::send_rc_channels() const
         values[15],
         values[16],
         values[17],
-        receiver_rssi);        
+        receiver_rssi);
 }
 
 bool GCS_MAVLINK::sending_mavlink1() const
@@ -1789,7 +1789,7 @@ void GCS::send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const cha
     strncpy(statustext.msg.text, text, sizeof(statustext.msg.text));
 
     WITH_SEMAPHORE(_statustext_sem);
-    
+
     // The force push will ensure comm links do not block other comm links forever if they fail.
     // If we push to a full buffer then we overwrite the oldest entry, effectively removing the
     // block but not until the buffer fills up.
@@ -2155,6 +2155,7 @@ void GCS_MAVLINK::send_autopilot_version() const
     );
 
     send_matternet_FTS_version();
+    send_rangefinder_versions();
 }
 
 
@@ -2441,7 +2442,7 @@ void GCS_MAVLINK::send_servo_output_raw()
         if (values[i] == 65535) {
             values[i] = 0;
         }
-    }    
+    }
     mavlink_msg_servo_output_raw_send(
             chan,
             AP_HAL::micros(),
@@ -2523,7 +2524,7 @@ void GCS_MAVLINK::zero_rc_outputs()
 }
 
 /*
-  handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command 
+  handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command
 
   Optionally disable PX4IO overrides. This is done for quadplanes to
   prevent the mixer running while rebooting which can start the VTOL
@@ -2937,9 +2938,9 @@ void GCS_MAVLINK::handle_common_vision_position_estimate_data(const uint64_t use
 {
     // correct offboard timestamp to be in local ms since boot
     uint32_t timestamp_ms = correct_offboard_timestamp_usec_to_ms(usec, payload_size);
-    
+
     // sensor assumed to be at 0,0,0 body-frame; need parameters for this?
-    // or a new message 
+    // or a new message
     const Vector3f sensor_offset = {};
     const Vector3f pos = {
         x,
@@ -3011,7 +3012,7 @@ void GCS_MAVLINK::handle_att_pos_mocap(const mavlink_message_t &msg)
                                angErr,
                                timestamp_ms,
                                reset_timestamp_ms);
-   
+
     // calculate euler orientation for logging
     float roll;
     float pitch;
@@ -3235,7 +3236,7 @@ void GCS_MAVLINK::handle_common_message(const mavlink_message_t &msg)
 
     case MAVLINK_MSG_ID_DATA96:
         handle_data_packet(msg);
-        break;        
+        break;
 
     case MAVLINK_MSG_ID_VISION_POSITION_DELTA:
         handle_vision_position_delta(msg);
@@ -3601,6 +3602,30 @@ void GCS_MAVLINK::send_matternet_FTS_version(void) const
     }
 }
 
+/*
+  send active rangefinders' version strings
+ */
+void GCS_MAVLINK::send_rangefinder_versions(void) const
+{
+
+    RangeFinder *rangefinder = RangeFinder::get_singleton();
+    if (rangefinder == nullptr) {
+        return;
+    }
+
+    for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
+        AP_RangeFinder_Backend *sensor = rangefinder->get_backend(i);
+        if (sensor == nullptr || sensor->get_version() == nullptr) {
+            continue;
+        }
+        else if (strcmp(sensor->get_version(),"") == 0) {
+            continue;
+        }
+        else {
+            gcs().send_text(MAV_SEVERITY_INFO, "RANGEFINDER: %s", sensor->get_version());
+        }
+    }
+}
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_send_banner(const mavlink_command_long_t &packet)
 {
@@ -3779,7 +3804,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     case MAV_CMD_BATTERY_RESET:
         result = handle_command_battery_reset(packet);
         break;
-        
+
     case MAV_CMD_PREFLIGHT_UAVCAN:
         result = handle_command_preflight_can(packet);
         break;
@@ -3859,7 +3884,7 @@ MAV_RESULT GCS_MAVLINK::handle_command_long_packet(const mavlink_command_long_t 
     case MAV_CMD_FIXED_MAG_CAL_YAW:
         result = handle_fixed_mag_cal_yaw(packet);
         break;
-        
+
     default:
         result = MAV_RESULT_UNSUPPORTED;
         break;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3607,22 +3607,22 @@ void GCS_MAVLINK::send_matternet_FTS_version(void) const
  */
 void GCS_MAVLINK::send_rangefinder_versions(void) const
 {
-
     RangeFinder *rangefinder = RangeFinder::get_singleton();
     if (rangefinder == nullptr) {
         return;
     }
-
+    char rangefinder_version[80];
     for (uint8_t i = 0; i < RANGEFINDER_MAX_INSTANCES; i++) {
         AP_RangeFinder_Backend *sensor = rangefinder->get_backend(i);
-        if (sensor == nullptr || sensor->get_version() == nullptr) {
+        if (sensor == nullptr) {
             continue;
         }
-        else if (strcmp(sensor->get_version(),"") == 0) {
+        sensor->get_version(rangefinder_version);
+        if (rangefinder_version == nullptr || strcmp(rangefinder_version, "") == 0) {
             continue;
         }
         else {
-            gcs().send_text(MAV_SEVERITY_INFO, "RANGEFINDER: %s", sensor->get_version());
+            gcs().send_text(MAV_SEVERITY_INFO, "RANGEFINDER: %s", rangefinder_version);
         }
     }
 }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3617,8 +3617,9 @@ void GCS_MAVLINK::send_rangefinder_versions(void) const
         if (sensor == nullptr) {
             continue;
         }
-        sensor->get_version(rangefinder_version, 80);
-        if (rangefinder_version == nullptr || strcmp(rangefinder_version, "") == 0) {
+        sensor->get_version(rangefinder_version, sizeof(rangefinder_version));
+        rangefinder_version[sizeof(rangefinder_version)-1] = '\0';  // Append '\0' at end of string for safety
+        if (strcmp(rangefinder_version, "") == 0) {
             continue;
         }
         else {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3617,7 +3617,7 @@ void GCS_MAVLINK::send_rangefinder_versions(void) const
         if (sensor == nullptr) {
             continue;
         }
-        sensor->get_version(rangefinder_version);
+        sensor->get_version(rangefinder_version, 80);
         if (rangefinder_version == nullptr || strcmp(rangefinder_version, "") == 0) {
             continue;
         }


### PR DESCRIPTION
Add send lidar (and general rangefinder) versions functionality over mavlink.

e.g. through mavproxy:
```
STABILIZE> version
STABILIZE> AP: MTTR_FTS_VER: UNKNOWN
AP: RANGEFINDER: I2C Lidar SF20,2.4.1,16 
```