### PR TITLE
MATE-2248 Always send MSG_AUTOPILOT_VERSION

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -810,7 +810,8 @@ bool GCS_MAVLINK::should_send_message_in_delay_callback(const ap_message id) con
     // No ID we return true for may take more than a few hundred
     // microseconds to return!
 
-    if (id == MSG_HEARTBEAT || id == MSG_NEXT_PARAM) {
+    // Messages to always send immediately
+    if (id == MSG_HEARTBEAT || id == MSG_NEXT_PARAM || id == MSG_AUTOPILOT_VERSION) {
         return true;
     }
 


### PR DESCRIPTION
`MSG_AUTOPILOT_VERSION` is blocked from being sent via Mavlink in SITL. This is due to the fact that this message is blocked when the HAL scheduler is delayed. This mostly occurs during sensor initialization.
This message can be unblocked by "whitelisting" it in the function `should_send_message_in_delay_callback()`, which will allow this message to be sent while the HAL scheduler is delayed. This fix has already been implemented in the [master Ardupilot branch](https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS_Common.cpp#L942) and has been approved by @peterbarker and @tridge for our SITL use.
This fix does not require any changes to the MATE source code.