### PR TITLE
Bugfix: Remove noisy debug

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1414,11 +1414,6 @@ AP_GPS_UBLOX::_parse_gps(void)
             GCS_SEND_TEXT(MAV_SEVERITY_ERROR,
                             "Unexpected GNSS PVT fix %d, flags %d", _buffer.pvt.fix_type, _buffer.pvt.flags);
         }
-        // Check if lat, lon, height, and hMSL valid
-        if (!(_buffer.pvt.flags3 & 0b00000001)) {
-            GCS_SEND_TEXT(MAV_SEVERITY_ERROR,
-                            "Unexpected GNSS PVT validity flag %d", _buffer.pvt.flags3);
-        }
         // Set fix status
         switch (_buffer.pvt.fix_type) 
         {


### PR DESCRIPTION
Removing debug that is throwing alerts at high frequency. Flag evaluation logic will need to be re-evaluated.