### PR TITLE
AS-206 Fix SNR reporting for RFND messaging

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1406,7 +1406,7 @@ struct PACKED log_Arm_Disarm {
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
-      "RFND", "QBCCBB", "TimeUS,Instance,Dist,Snr,Stat,Orient", "s#m---", "F-B---" }, \
+      "RFND", "QBCHBB", "TimeUS,Instance,Dist,Snr,Stat,Orient", "s#m---", "F-B---" }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "IIIIIBBBBBBBBB",         "TimeMS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "C-------------" }, \
     { LOG_BEACON_MSG, sizeof(log_Beacon), \


### PR DESCRIPTION
- fixed type format character for SNR in RFND message

Before: (in-flight data)
<img width="1383" alt="image (3)" src="https://user-images.githubusercontent.com/17605285/211919066-454044f9-008a-4e87-b81a-8282db50b3e0.png">

After: (Bench testing with M22013)
<img width="1363" alt="image (4)" src="https://user-images.githubusercontent.com/17605285/211919147-03f24973-7556-46b4-999b-34caafeb3942.png">

