### PR TITLE
AS-529 Use 16-bit ADC scaling for MfgTest

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -1485,6 +1485,9 @@ def write_PWM_config(f):
 
 def write_ADC_config(f, mfg_test=False):
     '''write ADC config defines'''
+    if mfg_test is True:
+        print("MfgTest uses 16-bit ADC scaling")
+
     f.write('// ADC config\n')
     adc_chans = []
     for l in bylabel:
@@ -1678,7 +1681,7 @@ def write_hwdef_header(outfilename):
 
     write_mcu_config(f)
     write_SPI_config(f)
-    write_ADC_config(f)
+    write_ADC_config(f, isMfgTest)
     write_GPIO_config(f)
     write_IMU_config(f)
     write_MAG_config(f)

--- a/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
+++ b/libraries/AP_HAL_ChibiOS/hwdef/scripts/chibios_hwdef.py
@@ -25,6 +25,12 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+# set MfgTest flag
+isMfgTest = False
+if "MfgTest" in args.hwdef:
+    print("MfgTest build selected!")
+    isMfgTest = True
+
 # output variables for each pin
 f4f7_vtypes = ['MODER', 'OTYPER', 'OSPEEDR', 'PUPDR', 'ODR', 'AFRL', 'AFRH']
 f1_vtypes = ['CRL', 'CRH', 'ODR']


### PR DESCRIPTION
- set MfgTest flag in waf processing to indicate MfgTest build
- use MfgTest flag to build with 16-bit ADC scaling