### PR TITLE
added new github action uploader

### DIFF
--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -99,14 +99,14 @@ jobs:
           Tools/scripts/mttr-build-ci.sh
 
       - name: Archive builds
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
            name: builds-${{matrix.config}}
            path: /tmp/deploy_files
            retention-days: 60
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -114,7 +114,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs


### PR DESCRIPTION
This PR updates the github action artifacts to version 4 from version 2 since version 2 has been deprecated since June 30 2024 as listed here https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

By using version 4 we will continue to upload artifacts as part of the github actions workflow.