### PR TITLE
Quick Stop Stage 1

### DIFF
--- a/ArduCopter/mode_brake.cpp
+++ b/ArduCopter/mode_brake.cpp
@@ -17,10 +17,8 @@ bool ModeBrake::init(bool ignore_checks)
     pos_control->set_max_accel_z(BRAKE_MODE_DECEL_RATE);
 
     // initialise position and desired velocity
-    if (!pos_control->is_active_z()) {
-        pos_control->set_alt_target_to_current_alt();
-        pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
-    }
+    pos_control->set_alt_target_to_current_alt();
+    pos_control->set_desired_velocity_z(inertial_nav.get_velocity_z());
 
     _timeout_ms = 0;
 


### PR DESCRIPTION
When brake mode initializes it always sets the current state and velocity to the current measured values.

Background: https://matternet.atlassian.net/browse/AS-815

Jira ticket: https://matternet.atlassian.net/browse/AS-821