### PR TITLE
Chore/AS-981: Update land detector rangefinder check

### DIFF
--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -1,4 +1,5 @@
 #include "Copter.h"
+#include <AP_RangeFinder/RangeFinder_Backend.h>
 
 // Code to detect a crash main ArduCopter code
 #define LAND_CHECK_ANGLE_ERROR_DEG  30.0f       // maximum angle error to be considered landing
@@ -74,7 +75,25 @@ void Copter::update_land_detector()
         bool descent_rate_low = fabsf(inertial_nav.get_velocity_z()) < 100;
 
         // if we have a healthy rangefinder only allow landing detection below 2 meters
-        bool rangefinder_check = (!rangefinder_alt_ok() || rangefinder_state.alt_cm_filt.get() < LAND_RANGEFINDER_MIN_ALT_CM);
+        bool rangefinder_check = false;
+        bool have_healthy_rangefinder = false;
+        for (uint8_t i=0; i<rangefinder.num_sensors(); i++) {
+            AP_RangeFinder_Backend *sensor = rangefinder.get_backend(i);
+            if (sensor->orientation() != ROTATION_PITCH_270 || sensor->status() != RangeFinder::RangeFinder_Good) {
+                continue;
+            }
+            have_healthy_rangefinder = true;
+            if (sensor->distance_cm() < LAND_RANGEFINDER_MIN_ALT_CM) {
+                rangefinder_check = true;
+                break;
+            }
+        }
+        if (!have_healthy_rangefinder) {
+            // if we have no healthy rangefinder than consider the
+            // rangefinder check a pass, and we rely on the other
+            // components of the landing detector
+            rangefinder_check = true;
+        }
 
         if (motor_at_lower_limit && accel_stationary && descent_rate_low && rangefinder_check) {
             // landed criteria met - increment the counter and check if we've triggered


### PR DESCRIPTION
This change was applied to mttr-rebase-3.6.7 and was not applied to mttr-rebase-4.0. This change considers the rangefinder check met if any healthy rangefinder is below the minimum alt threshold (200cm), rather than requiring both rangefinders to meet the criteria. This addresses the issue when radar reports invalid data close to the ground and the status is "GOOD", i.e. radar does not know that it is out of range.

Original implementation: https://github.com/matternet/ardupilot/pull/97
Jira ticket: https://matternet.atlassian.net/browse/AS-981
NCT: https://matternet.atlassian.net/browse/NCT-3311

