### PR TITLE
Fix/AS-989: Change blended to single GPS switch logic

### DIFF
--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -7,7 +7,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -17,7 +17,7 @@ jobs:
         ]
     steps:
       # git checkout the PR
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       # Put ccache into github cache for faster build
@@ -27,7 +27,7 @@ jobs:
           NOW=$(date -u +"%F-%T")
           echo "::set-output name=timestamp::${NOW}"
       - name: ccache cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v2
         with:
           path: ~/.ccache
           key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
@@ -52,7 +52,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     container:
       image: ardupilot/ardupilot-dev-base:latest
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       # git checkout the PR
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
       # Put ccache into github cache for faster build
@@ -75,7 +75,7 @@ jobs:
           NOW=$(date -u +"%F-%T")
           echo "::set-output name=timestamp::${NOW}"
       - name: ccache cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v2
         with:
           path: ~/.ccache
           key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -7,7 +7,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:latest
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -17,7 +17,7 @@ jobs:
         ]
     steps:
       # git checkout the PR
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       # Put ccache into github cache for faster build
@@ -27,7 +27,7 @@ jobs:
           NOW=$(date -u +"%F-%T")
           echo "::set-output name=timestamp::${NOW}"
       - name: ccache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.ccache
           key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
@@ -52,7 +52,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:latest
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       # git checkout the PR
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       # Put ccache into github cache for faster build
@@ -75,7 +75,7 @@ jobs:
           NOW=$(date -u +"%F-%T")
           echo "::set-output name=timestamp::${NOW}"
       - name: ccache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.ccache
           key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1025,19 +1025,33 @@ void AP_GPS::update_primary(void)
     if (primary_instance == GPS_BLENDED_INSTANCE) {
         primary_instance = 0;
         for (uint8_t i=1; i<GPS_MAX_RECEIVERS; i++) {
-            // choose GPS with highest state or higher number of satellites with at least
-            if (state[i].status < GPS_OK_FIX_3D) {
+            // Choose GPS with highest state or higher number of satellites.
+            // Reject a GPS with an old update time, as it may be the old timestamp that triggered the loss of blending
+            const uint32_t delay_threshold_ms = 400;
+            const bool higher_status = state[i].status > state[primary_instance].status;
+            const bool old_data_primary = (now - state[primary_instance].last_gps_time_ms) > delay_threshold_ms;
+            const bool old_data = (now - state[i].last_gps_time_ms) < delay_threshold_ms;
+            const bool equal_status = (state[i].status == state[primary_instance].status);
+            const bool more_sats = (state[i].num_sats > state[primary_instance].num_sats);
+
+            if (old_data && !old_data_primary) {
+                // Don't switch to a GPS that has not updated in 400ms
                 continue;
             }
-            if ((state[i].status > state[primary_instance].status) ||
-                ((now - state[primary_instance].last_gps_time_ms) > 400 &&
-                 (now - state[i].last_gps_time_ms) < 400) ||
-                ((state[i].status == state[primary_instance].status) && (state[i].num_sats > state[primary_instance].num_sats))) {
+
+            if (state[i].status < GPS_OK_FIX_3D) {
+                // Don't use a GPS without 3D fix or better
+                continue;
+            }
+
+            // Select the new GPS if the primary has old data,
+            // or new GPS either has higher status,
+            // or has the same status and more satellites
+            if ((old_data_primary && !old_data) || higher_status || (equal_status && more_sats)) {
                 primary_instance = i;
-                _last_instance_swap_ms = now;
             }
         }
-        gcs().send_text(MAV_SEVERITY_CRITICAL, "GPS Switch: Switched from Blended to %u", primary_instance+1);
+        _last_instance_swap_ms = now;
         return;
     }
 


### PR DESCRIPTION
Currently, if a GPS does not update within 400ms, it is possible for the autopilot to erroneously select this stale GPS as primary, if the stale GPS has a higher number of satellites or equal fix to the blended solution. The logic should validate the last updated time, status, and number of satellites first before switching away from blended to the desired GPS.

Compare to https://github.com/ArduPilot/ardupilot/blob/1ba82e4c07aff8d80875cc4717052068b17a709f/libraries/AP_GPS/AP_GPS.cpp#L1155-L1190

Jira ticket: https://matternet.atlassian.net/browse/AS-989
NCT with occurrence: https://matternet.atlassian.net/browse/NCT-3299
