### PR TITLE
Fix/AS-1306: Remove magnetometer variance from EKF failsafe check

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -105,13 +105,8 @@ bool Copter::ekf_over_threshold()
     Vector2f offset;
     ahrs.get_variances(vel_variance, position_variance, height_variance, mag_variance, tas_variance, offset);
 
-    const float mag_max = fmaxf(fmaxf(mag_variance.x,mag_variance.y),mag_variance.z);
-
-    // return true if two of compass, velocity and position variances are over the threshold OR velocity variance is twice the threshold
+    // return true if both velocity and position variances are over the threshold OR velocity variance is twice the threshold
     uint8_t over_thresh_count = 0;
-    if (mag_max >= g.fs_ekf_thresh) {
-        over_thresh_count++;
-    }
     if (!optflow.healthy() && (vel_variance >= (2.0f * g.fs_ekf_thresh))) {
         over_thresh_count += 2;
     } else if (vel_variance >= g.fs_ekf_thresh) {


### PR DESCRIPTION
The EKF failsafe check in ekf_over_threshold() previously required two out of three of magnetometer, position, or velocity variances to exceed a threshold (or velocity alone to exceed twice the threshold) to trigger an EKF failsafe (i.e., FTS / parachute deployment).

Because magnetometer variance commonly spikes for reasons that do not warrant an FTS trigger and that are unrelated to position/velocity uncertainty, this change removes magnetometer variance from the check. No other behavior is changed, including the compass-variance pre-arm check (AP_Arming.cpp).

Jira ticket: https://matternet.atlassian.net/browse/AS-1306
