### PR TITLE
Fix/AS-1452: Log magnetometer during COMPASS_USE cutoff windows

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -237,6 +237,21 @@ void NavEKF2_core::SelectMagFusion()
     // used for load levelling
     magFusePerformed = false;
 
+    // Log the compass whenever a fresh healthy sample arrives, even when it is not being fused (e.g.
+    // during a COMPASS_USE = 0 mag cutoff), so the MAG message stays present in the dataflash / replay
+    // log. This must run before the !use_compass() early-return below: that branch skips readMagData()
+    // (and therefore all mag logging) for the entire duration of a cutoff. Dedicated throttle because
+    // Write_Compass() has no internal rate limit and this runs at the filter rate; the 70ms cap matches
+    // the fusion cadence in readMagData().
+    if (_ahrs->get_compass() != nullptr) {
+        auto &compass = *_ahrs->get_compass();
+        if (compass.healthy(magSelectIndex) &&
+            compass.last_update_usec(magSelectIndex) - lastMagLog_us > 70000) {
+            frontend->logging.log_compass = true;
+            lastMagLog_us = compass.last_update_usec(magSelectIndex);
+        }
+    }
+
     // Handle case where we are not using a yaw sensor of any type and and attempt to reset the yaw in
     // flight using the output from the GSF yaw estimator.
     if (!use_compass() && tiltAlignComplete) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -350,6 +350,7 @@ void NavEKF2_core::InitialiseVariablesMag()
 {
     lastHealthyMagTime_ms = imuSampleTime_ms;
     lastMagUpdate_us = 0;
+    lastMagLog_us = 0;
     magYawResetTimer_ms = imuSampleTime_ms;
     magTimeout = false;
     allMagSensorsFailed = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -842,6 +842,7 @@ private:
     uint32_t prevTasStep_ms;        // time stamp of last TAS fusion step
     uint32_t prevBetaStep_ms;       // time stamp of last synthetic sideslip fusion step
     uint32_t lastMagUpdate_us;      // last time compass was updated in usec
+    uint32_t lastMagLog_us;         // last time compass was logged in usec (throttle for logging when not fused)
     uint32_t lastMagRead_ms;        // last time compass data was successfully read
     Vector3f velDotNED;             // rate of change of velocity in NED frame
     Vector3f velDotNEDfilt;         // low pass filtered velDotNED


### PR DESCRIPTION
## Summary

The AS-1452 mag-denied-landing feature (MATE side) disables magnetometer fusion for the final descent by
setting `COMPASS_USE` / `COMPASS_USE2 = 0`. On builds with EKF logging enabled (`LOG_REPLAY = 1` and
`EK2_LOG_MASK != 0`), the `MAG` dataflash message **disappears for the entire cutoff window** — so we lose
the compass trace over exactly the interval the feature acts on. This restores continuous `MAG` logging
during the cutoff, with **no change to fusion**.

## Root cause

When EKF logging is active, `AP::ahrs().have_ekf_logging()` is true, so the compass driver hands MAG
logging to the EKF (`AP_Compass` logs nothing). The EKF emits `MAG` only via
`NavEKF2::check_log_write()` consuming `frontend->logging.log_compass`, and that flag was set **only inside
`readMagData()`**.

But `readMagData()` is not called during a cutoff: `SelectMagFusion()` early-returns on
`!use_compass() && tiltAlignComplete` *before* it reaches the `readMagData()` call. With `use_compass()`
false while `COMPASS_USE = 0`, `log_compass` is never set → no `MAG` rows for the whole window.

## Change

Move the compass-logging trigger to the **top of `SelectMagFusion()`**, ahead of the `!use_compass()`
early-return, so a fresh healthy sample is logged every filter frame regardless of fusion state. A
dedicated `lastMagLog_us` throttle (70 ms, matching the fusion cadence) prevents over-logging. The
`readMagData()` / fusion path is left exactly at stock.

- `libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp` — logging block above the early-return
- `libraries/AP_NavEKF2/AP_NavEKF2_core.h` / `.cpp` — `lastMagLog_us` member + init

Net: 3 files, +17 lines, no fusion behavior change (`AP_NavEKF2_Measurements.cpp` is untouched/stock).

## Scope

**EKF2 only**, per the shipped config (`AHRS_EKF_TYPE = 2`, `EK3_ENABLE = 0`). The identical early-return
gate exists in `AP_NavEKF3_MagFusion.cpp`, but EKF3 is disabled, so it is intentionally not patched.

## Safety / replay

- **No fusion change.** `log_compass` is a per-frame bool consumed once by `check_log_write()`. The mag is
  still not fused while cut — the fusion block in `readMagData()` remains fully `use_compass()`-gated.
- **Fail-safe paths untouched** (cut fails safe to mag-on; re-enable retries indefinitely — unchanged).
- **Replay-safe.** `MAG` is a replay *input*, and `COMPASS_USE` PARM changes are replayed, so a replayed
  EKF re-derives `use_compass() == false` during the cutoff and declines to fuse the newly-logged samples —
  matching flight. The change makes the log self-sufficient for replaying the non-fusing window.

## Verification (SITL)

Built SITL and flew mag-denied landings with `LOG_REPLAY = 1`, `EK2_LOG_MASK = 1`, `AHRS_EKF_TYPE = 2`
(i.e. `have_ekf_logging()` true — the exact condition that produced the dropout). Result:

- `MAG` rows are now present **continuously through the `COMPASS_USE = 0` window** (~10 Hz; max
  inter-sample gap 0.10 s = the compass sample interval — no gap), and unchanged outside it.
- Before this change, `MAG` was absent for the entire window.

Ticket: AS-1452
