### PR TITLE
Feat/AS-1555: AP_Arming - Configurable parameters for pre-arm mag field limits

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -49,8 +49,6 @@
 #include <AP_Logger/AP_Logger.h>
 
 #define AP_ARMING_COMPASS_MAGFIELD_EXPECTED 530
-#define AP_ARMING_COMPASS_MAGFIELD_MIN  200     // 250 milligauss min closer to the equator, give 50 mG buffer
-#define AP_ARMING_COMPASS_MAGFIELD_MAX  700     // 650 milligauss max closer to poles, give 50 mG buffer
 #define AP_ARMING_BOARD_VOLTAGE_MAX     5.8f
 #define AP_ARMING_ACCEL_ERROR_THRESHOLD 0.75f
 #define AP_ARMING_AHRS_GPS_ERROR_MAX    10      // accept up to 10m difference between AHRS and GPS
@@ -114,6 +112,24 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Bitmask{Plane}: 0:All,1:Barometer,2:Compass,3:GPS lock,4:INS,5:Parameters,6:RC Channels,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS Configuration,13:System,14:Mission,15:Rangefinder
     // @User: Standard
     AP_GROUPINFO("CHECK",        8,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
+
+    // @Param: MAGF_MIN
+    // @DisplayName: Compass magnetic field strength minimum
+    // @Description: This sets the minimum acceptable magnetic field strength for the pre-arm compass check.
+    // @Range: 0 500
+    // @Units: mGauss
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("MAGF_MIN",     9,     AP_Arming,  _magfield_min_mG,        200.0f),
+
+    // @Param: MAGF_MAX
+    // @DisplayName: Compass magnetic field strength maximum
+    // @Description: This sets the maximum acceptable magnetic field strength for the pre-arm compass check.
+    // @Range: 500 2000
+    // @Units: mGauss
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("MAGF_MAX",     10,    AP_Arming,  _magfield_max_mG,        700.0f),
 
     AP_GROUPEND
 };
@@ -428,7 +444,7 @@ bool AP_Arming::compass_checks(bool report)
 
         // check for unreasonable mag field length
         const float mag_field = _compass.get_field().length();
-        if (mag_field > AP_ARMING_COMPASS_MAGFIELD_MAX || mag_field < AP_ARMING_COMPASS_MAGFIELD_MIN) {
+        if (mag_field > _magfield_max_mG || mag_field < _magfield_min_mG) {
             check_failed(ARMING_CHECK_COMPASS, report, "Check mag field");
             return false;
         }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -97,6 +97,12 @@ protected:
     AP_Int8                 _rudder_arming;
     AP_Int32                 _required_mission_items;
 
+    // Minimum magnetic field strength for the pre-arm compass check, in mG
+    AP_Float                _magfield_min_mG;
+
+    // Maximum magnetic field strength for the pre-arm compass check, in mG
+    AP_Float                _magfield_max_mG;
+
     // internal members
     bool                    armed;
     uint32_t                last_accel_pass_ms[INS_MAX_INSTANCES];


### PR DESCRIPTION
## Summary

The pre-arm compass check rejects arming when the primary compass field magnitude falls outside fixed compile-time limits (`AP_ARMING_COMPASS_MAGFIELD_MIN` / `MAX` = 200 / 700 mGauss). This converts those defines into runtime parameters so the limits can be tuned per site / vehicle without a firmware build, following the pattern of the configurable compass-consistency limits from #210 (`COMPASS_AD_MAX` / `ADXY_MAX` / `LDXY_MAX`, 00241e5c93).

| Parameter | Default | Range | Units |
|---|---|---|---|
| `ARMING_MAGF_MIN` | 200 | 0 – 500 | mGauss |
| `ARMING_MAGF_MAX` | 700 | 500 – 2000 | mGauss |

Defaults are unchanged, so stock behavior is preserved.

## Change

- `libraries/AP_Arming/AP_Arming.cpp` — defines removed; two `AP_GROUPINFO` entries added at the next free indices (9, 10) in `AP_Arming::var_info`; `compass_checks()` compares against the new members.
- `libraries/AP_Arming/AP_Arming.h` — the two `AP_Float` members.

Notes: full names stay within the 16-char `AP_Param` limit (`ARMING_MAGF_MIN` = 15); indices 9/10 are unused, including by `AP_Arming_Plane`'s nested group.

## Verification (SITL)

Built SITL copter (boots clean, both params registered at defaults) and ran a live test changing the limits in real time while disarmed, with the field steady at ~481 mGauss:

1. `ARMING_MAGF_MAX` 700 → **300** — field out of bounds; arming blocked, `PreArm: Check mag field` reported; restored to 700 and the failure cleared.
2. `ARMING_MAGF_MIN` 200 → **600** — same result from the low side; restored to 200 and the failure cleared.
3. `ARMING_MAGF_MAX` 700 → **1500** — field stays in bounds; no failure (no false positive when widening).

<img width="1860" height="810" alt="AS-1555-magfield-prearm-plot" src="https://github.com/user-attachments/assets/477c0c55-7d14-4845-8c52-1ce6605fc52d" />

The plot shows the logged `MAG` field magnitude against both limits over time, with the out-of-bounds windows shaded and the logged pre-arm failures marked. Two reading notes: the pre-arm *clear* is not logged (only failure text is emitted), so only failure onsets are marked — the clears were confirmed live; and the gap between a param change and the logged failure text is the reporting cycle, not the check itself. The checks run at 1 Hz (`Copter::one_hz_loop()` → `arming.update()`), so arming is blocked within ~1 s, but the failure message is only emitted every 30 s (`PREARM_DISPLAY_PERIOD`) — the two logged failures land exactly 30.000 s apart on that clock.

Ticket: https://matternet.atlassian.net/browse/AS-1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
