### PR TITLE
Fix/AS-1554: Use AHRS location instead of GPS in compass cal fix_radius

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -939,14 +939,15 @@ bool CompassCalibrator::calculate_orientation(void)
  */
 bool CompassCalibrator::fix_radius(void)
 {
-    if (AP::gps().status() < AP_GPS::GPS_OK_FIX_2D) {
+    struct Location loc;
+    if (!AP::ahrs().get_position(loc) && !AP::ahrs().get_origin(loc)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "MagCal: No location, fix_radius skipped");
         // we don't have a position, leave scale factor as 0. This
         // will disable use of WMM in the EKF. Users can manually set
         // scale factor after calibration if it is known
         _params.scale_factor = 0;
         return true;
     }
-    const struct Location &loc = AP::gps().location();
     float intensity;
     float declination;
     float inclination;


### PR DESCRIPTION
Port of upstream ArduPilot commits 325d6f6c94 and 64e859ecc5: gate fix_radius() on the AHRS position with an EKF-origin fallback instead of the live GPS fix state, and warn via GCS when no location is available.

The EKF origin is latched the first time the vehicle gets a fix after boot, so a fix lost mid-calibration (e.g. antenna facing the ground while the vehicle is held inverted) no longer silently zeroes COMPASS_SCALE/COMPASS_SCALE2 when the fit happens to complete during the outage. Confirmed 8-for-8 against the FTEST-15281 calibration test logs: every zeroed scale coincided with no-2D-fix at that compass's completion instant, and every run had a fix (and hence an origin) at boot. Upstream's get_location() is get_position() in this tree.

https://matternet.atlassian.net/browse/AS-1554

Calibrations were run to test this change, with good results; see https://matternet.atlassian.net/browse/FTEST-15383 for test information and https://matternet.atlassian.net/browse/LOG-2061 for log review.

The correct error message also appeared in the test where GPS fix was not available at any point in the power cycle (this should be very rare in practice):
<img width="746" height="110" alt="Screenshot 2026-08-17 140320" src="https://github.com/user-attachments/assets/a2c25426-1afe-4b4d-8f46-fa9851179ebc" />
